### PR TITLE
Removed excess semicolon.

### DIFF
--- a/Sources/arm/ui/UIFiles.hx
+++ b/Sources/arm/ui/UIFiles.hx
@@ -200,7 +200,7 @@ class UIFiles {
 		#elseif krom_android
 		"/sdcard"
 		#elseif krom_darwin
-		"/Users";
+		"/Users"
 		#else
 		"/"
 		#end


### PR DESCRIPTION
There is an excess semicolon at the end of the line 203 of `UIFiles.hx` that leads to the build breaking on macOS/Darwin with:

```Shell
~/code/armorpaint/Sources/arm/ui/UIFiles.hx:207: characters 2-3 : Expected }
```