### PR TITLE
fix windows build with github action (it will now create an artifact) and update README.md for describing how to launch without doing "Set `Project - Properties - Debugging - Command Arguments` to `..\..\build\krom`"

### DIFF
--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -36,6 +36,6 @@ jobs:
       with:
         path: build/
     - name: publish build
-          uses: actions/upload-artifact@v2
-          with:
-            path: Kromx/
+      uses: actions/upload-artifact@v2
+      with:
+        path: Kromx/

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -30,7 +30,8 @@ jobs:
         pathTarget: Kromx/v8/libraries/win32/release/
     - name: Kinc and compile
     - run: cd Kromx;node Kinc/make -g direct3d11 --compile
-      - name: publish build
-        uses: actions/upload-artifact@v2
-        with:
-          path: *build *Kromx
+      shell: pwsh
+    - name: publish build
+      uses: actions/upload-artifact@v2
+      with:
+        path: *build *Kromx

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -34,5 +34,4 @@ jobs:
     - name: publish build
       uses: actions/upload-artifact@v2
       with:
-        path: '**build'
-        path: '**Kromx'
+        path: '**build **Kromx'

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -34,4 +34,8 @@ jobs:
     - name: publish build
       uses: actions/upload-artifact@v2
       with:
-        path: '[bK]'
+        path: build/
+    - name: publish build
+          uses: actions/upload-artifact@v2
+          with:
+            path: Kromx/

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -34,4 +34,4 @@ jobs:
     - name: publish build
       uses: actions/upload-artifact@v2
       with:
-        path: '**build **Kromx'
+        path: '[bK]'

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -29,7 +29,7 @@ jobs:
         pathSource: Kromx/v8/libraries/win32/release/v8_monolith.7z
         pathTarget: Kromx/v8/libraries/win32/release/
     - name: Kinc and compile
-    - run: cd Kromx;node Kinc/make -g direct3d11 --compile
+      run: cd Kromx;node Kinc/make -g direct3d11 --compile
       shell: pwsh
     - name: publish build
       uses: actions/upload-artifact@v2

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -34,8 +34,8 @@ jobs:
     - name: publish build
       uses: actions/upload-artifact@v2
       with:
-        path: build/
+        path: build/krom
     - name: publish build
       uses: actions/upload-artifact@v2
       with:
-        path: Kromx/
+        path: Kromx/build/x64/

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -29,7 +29,7 @@ jobs:
         pathSource: Kromx/v8/libraries/win32/release/v8_monolith.7z
         pathTarget: Kromx/v8/libraries/win32/release/
     - name: Kinc and compile
-      run: cd Kromx;node Kinc/make -g direct3d11 --compile
+    - run: cd Kromx;node Kinc/make -g direct3d11 --compile
       - name: publish build
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -33,3 +33,6 @@ jobs:
       shell: pwsh
     - name: publish build
       uses: actions/upload-artifact@v2
+      with:
+        path: '**build'
+        path: '**Kromx'

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -30,3 +30,7 @@ jobs:
         pathTarget: Kromx/v8/libraries/win32/release/
     - name: Kinc and compile
       run: cd Kromx;node Kinc/make -g direct3d11 --compile
+      - name: publish build
+        uses: actions/upload-artifact@v2
+        with:
+          path: *build *Kromx

--- a/.github/workflows/windowsbuild.yml
+++ b/.github/workflows/windowsbuild.yml
@@ -33,5 +33,3 @@ jobs:
       shell: pwsh
     - name: publish build
       uses: actions/upload-artifact@v2
-      with:
-        path: *build *Kromx

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ node Kinc/make -g direct3d11
 # Set `Project - Properties - Debugging - Command Arguments` to `..\..\build\krom`
 # Build for x64 & release
 ```
+
+If you don't do the "Project - Properties - Debugging - Command Arguments" step, you can launc from command line with
+```bash
+cd whereisyourkromexecutable
+.\Krom.exe whereisthekromjsfileloacated
+```
 ```bash
 # Linux
 node Kromx/make -g opengl


### PR DESCRIPTION
Now capable of easy releasing with github actions