### PR TITLE
Add a Makefile to make building on Linux easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+MAKEFLAGS += --silent
+
+.PHONY: all
+all:
+	node Kromx/make -g opengl
+	cd Kromx && node Kinc/make -g opengl --compiler clang --compile
+	strip Kromx/Deployment/Krom
+
+.PHONY: clean
+clean:
+	rm -rf build
+	git submodule foreach --recursive git clean -dfx


### PR DESCRIPTION
After installing dependencies, ArmorPaint can be compiled by simply running `make` in the root folder.

`make clean` can also be used to clean up build files.