### PR TITLE
Fixed the start position of strings in CJK languages

### DIFF
--- a/Sources/arm/Translator.hx
+++ b/Sources/arm/Translator.hx
@@ -76,6 +76,7 @@ class Translator {
 		}
 
 		if (cjk) {
+			kha.graphics2.Graphics.fontGlyphs.sort(Reflect.compare);
 			// Load and assign font with cjk characters
 			iron.App.notifyOnInit(function() {
 				iron.data.Data.getFont("font_cjk.ttf", function(f: kha.Font) {


### PR DESCRIPTION
The following code has `kha.graphics2.Graphics.fontGlyphs` as a continuous sequence will work correctly.
https://github.com/armory3d/Kromx/blob/d260a709880fc9b7e3869435e99dec7734e3d555/Sources/kha/Kravur.hx#L152-L162
Translation strings are not in the same order, so you can sort them to draw the correct characters.
![image](https://user-images.githubusercontent.com/1295639/85210284-99256180-b379-11ea-8b29-4720b580c527.png)
