### PR TITLE
Use placeholder in tr

### DIFF
--- a/Assets/locale/es.json
+++ b/Assets/locale/es.json
@@ -263,7 +263,7 @@
     "Bake": "Renderizar",
     "ColorID": "ColorID",
     "Picker": "Seleccionador",
-    "Hold ALT to set source": "Manten Alt para definir la fuente",
+    "Hold {key} to set source": "Manten {key} para definir la fuente",
     "Gizmo": "Gizmo",
     "Edit": "Editar",
     "Mode": "Modo",

--- a/Assets/locale/ja.json
+++ b/Assets/locale/ja.json
@@ -316,8 +316,7 @@
     "ColorID": "カラーID",
     "Picker": "ピッカー",
     "Gizmo": "ギズモ",
-    "Hold": "",
-    "to set source": "を長押ししてソースを設定します",
+    "Hold {key} to set source": "{key}を長押ししてソースを設定します",
     "Normal Map": "法線マップ",
     "Tiled": "タイル"
 }

--- a/Assets/locale/zh_CN.json
+++ b/Assets/locale/zh_CN.json
@@ -262,7 +262,7 @@
     "Bake": "烘焙",
     "ColorID": "颜色ID",
     "Picker": "拾取器",
-    "Hold ALT to set source": "按住ALT键设置源文件",
+    "Hold {key} to set source": "按住{key}键设置源文件",
     "Gizmo": "Gizmo",
     "Edit": "编辑",
     "Mode": "模式",

--- a/Sources/arm/ui/UIToolbar.hx
+++ b/Sources/arm/ui/UIToolbar.hx
@@ -51,7 +51,7 @@ class UIToolbar {
 					"(" + Config.keymap.tool_fill + ")",
 					"(" + Config.keymap.tool_decal + ")",
 					"(" + Config.keymap.tool_text + ")",
-					"(" + Config.keymap.tool_clone + ") - " + tr("Hold") + " (" + Config.keymap.set_clone_source + ") " + tr("to set source"),
+					"(" + Config.keymap.tool_clone + ") - " + tr("Hold {key} to set source", ["key" => Config.keymap.set_clone_source]),
 					"(" + Config.keymap.tool_blur + ")",
 					"(" + Config.keymap.tool_particle + ")",
 					"(" + Config.keymap.tool_colorid + ")",


### PR DESCRIPTION
Placeholders are used because the structure of sentences in English and Japanese is different.
For example, the common order in Japanese and Hangul is subject-object-verb.