### PR TITLE
Fixed a freeze when switching to cjk language in gumroad version

### DIFF
--- a/Sources/arm/Translator.hx
+++ b/Sources/arm/Translator.hx
@@ -85,6 +85,10 @@ class Translator {
 
 		if (cjk) {
 			kha.graphics2.Graphics.fontGlyphs.sort(Reflect.compare);
+			if (!File.exists(Path.data() + Path.sep + "font_cjk.ttc")) {
+				translations.clear();
+				return;
+			}
 			// Load and assign font with cjk characters
 			iron.App.notifyOnInit(function() {
 				iron.data.Data.getFont("font_cjk.ttc", function(f: kha.Font) {


### PR DESCRIPTION
The gumroad version does not include font_cjk.ttc, so it will not work if you switch to the cjk language.
So, switch the language if font_cjk.ttc exists.
