### PR TITLE
Warp Node feature

### DIFF
--- a/Libraries/shaderlib/Sources/arm/shader/MaterialParser.hx
+++ b/Libraries/shaderlib/Sources/arm/shader/MaterialParser.hx
@@ -549,7 +549,7 @@ class MaterialParser {
 		else if (node.type == "BLUR") {
 			if (blur_passthrough) return parse_vector_input(node.inputs[0]);
 			var strength = parse_value_input(node.inputs[1]);
-			if (strength == "0") return "vec3(0.0, 0.0, 0.0)";
+			if (strength == "0.0") return "vec3(0.0, 0.0, 0.0)";
 			var steps = 'int($strength * 10 + 1)';
 			var tex_name = "texblur_" + node_name(node);
 			curshader.add_uniform("sampler2D " + tex_name, "_" + tex_name);

--- a/Libraries/shaderlib/Sources/arm/shader/MaterialParser.hx
+++ b/Libraries/shaderlib/Sources/arm/shader/MaterialParser.hx
@@ -517,10 +517,43 @@ class MaterialParser {
 			var gamma = parse_value_input(node.inputs[1]);
 			return 'pow($out_col, ' + to_vec3('$gamma') + ")";
 		}
+
+		else if(node.type == "DIRECT_WARP"){
+			// Already fetched
+			if (parsed.indexOf(res_var_name(node, node.outputs[0])) >= 0) {
+			 	var varname = store_var_name(node);
+			}
+
+			// Load the warp mask
+			var mask_name = node_name(node);
+			var tex = make_texture(node, mask_name);
+			// Initialize the grayscale value in case no mask registered
+			curshader.write('float gray = 0;');
+			if (tex != null) {
+				var texstore = texture_store(node, tex, mask_name, true);
+				// Get the relevant mask-fragment grayscale value 
+				curshader.write('vec3 color = texture($mask_name, texCoord).rgb;');
+				curshader.write('gray = dot(color, vec3(0.299, 0.587, 0.114));');
+			}
+
+			// Load the current exisitng material texture and transform it
+			if (blur_passthrough) return parse_vector_input(node.inputs[0]);
+			var strength = Std.parseFloat(parse_value_input(node.inputs[1])) * 500;
+			var tex_name = "texblur_" + node_name(node);
+			curshader.add_uniform("sampler2D " + tex_name, "_" + tex_name);
+			var angle_rad = Std.parseFloat(parse_value_input(node.inputs[2])) * (Math.PI / 180);
+			var x =  Math.cos(angle_rad) * strength;
+			var y =  Math.sin(angle_rad) * strength;
+			curshader.write('vec3 res1 = vec3(0.0, 0.0, 0.0);');
+			curshader.write('res1 += texture($tex_name, texCoord + vec2($x, $y) * gray / vec2(textureSize($tex_name, 0))).rgb;');
+
+			return "res1";
+		}
+
 		else if (node.type == "BLUR") {
 			if (blur_passthrough) return parse_vector_input(node.inputs[0]);
 			var strength = parse_value_input(node.inputs[1]);
-			if (strength == "0.0") return "vec3(0.0, 0.0, 0.0)";
+			if (strength == "0") return "vec3(0.0, 0.0, 0.0)";
 			var steps = 'int($strength * 10 + 1)';
 			var tex_name = "texblur_" + node_name(node);
 			curshader.add_uniform("sampler2D " + tex_name, "_" + tex_name);

--- a/Libraries/shaderlib/Sources/arm/shader/NodesMaterial.hx
+++ b/Libraries/shaderlib/Sources/arm/shader/NodesMaterial.hx
@@ -1298,16 +1298,6 @@ class NodesMaterial {
 					{
 						id: 0,
 						node_id: 0,
-						name: _tr("Strength"),
-						type: "VALUE",
-						color: 0xffa1a1a1,
-						default_value: 0.5,
-						min: 0.0,
-						max: 1.0
-					},
-					{
-						id: 0,
-						node_id: 0,
 						name: _tr("Angle"),
 						type: "VALUE",
 						color: 0xffa1a1a1,
@@ -1319,9 +1309,11 @@ class NodesMaterial {
 						id: 0,
 						node_id: 0,
 						name: _tr("Mask"),
-						type: "RGBA",
-						color: 0xffc7c729,
-						default_value: f32([0.8, 0.8, 0.8, 1.0])
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.5,
+						min: 0.0,
+						max: 1.0
 					}
 				],
 				outputs: [

--- a/Libraries/shaderlib/Sources/arm/shader/NodesMaterial.hx
+++ b/Libraries/shaderlib/Sources/arm/shader/NodesMaterial.hx
@@ -1281,6 +1281,62 @@ class NodesMaterial {
 		[ // Color
 			{
 				id: 0,
+				name: _tr("Warp"),
+				type: "DIRECT_WARP", // extension
+				x: 0,
+				y: 0,
+				color: 0xff448c6d,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Strength"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.5,
+						min: 0.0,
+						max: 1.0
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Angle"),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0,
+						min: 0.0,
+						max: 360.0
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					}
+				],
+				buttons: [
+					{
+						name: _tr("File"),
+						type: "ENUM",
+						default_value: 0,
+						data: ""
+					}
+				]
+			},
+			{
+				id: 0,
 				name: _tr("Blur"),
 				type: "BLUR", // extension
 				x: 0,

--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -571,7 +571,7 @@ class App {
 	}
 
 	public static function enumTexts(nodeType: String): Array<String> {
-		if (nodeType == "TEX_IMAGE" || nodeType == "DIRECT_WARP") {
+		if (nodeType == "TEX_IMAGE") {
 			return Project.assetNames.length > 0 ? Project.assetNames : [""];
 		}
 		else if (nodeType == "LAYER" || nodeType == "LAYER_MASK") {

--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -571,7 +571,7 @@ class App {
 	}
 
 	public static function enumTexts(nodeType: String): Array<String> {
-		if (nodeType == "TEX_IMAGE") {
+		if (nodeType == "TEX_IMAGE" || nodeType == "DIRECT_WARP") {
 			return Project.assetNames.length > 0 ? Project.assetNames : [""];
 		}
 		else if (nodeType == "LAYER" || nodeType == "LAYER_MASK") {

--- a/Sources/arm/node/MakeMaterial.hx
+++ b/Sources/arm/node/MakeMaterial.hx
@@ -230,7 +230,6 @@ class MakeMaterial {
 				if (mask_node == null){
 					mask_node = node;
 				} 
-				// TODO: can't we add a node without inputs??
 				RenderUtil.makeNodePreview(UINodes.inst.getCanvasMaterial(), mask_node, mask);
 				MaterialParser.warp_passthrough = false;
 			}

--- a/Sources/arm/node/MakeMaterial.hx
+++ b/Sources/arm/node/MakeMaterial.hx
@@ -206,31 +206,8 @@ class MakeMaterial {
 				// Crate render target for the original image
 				var wimage = kha.Image.createRenderTarget(Std.int(Config.getTextureResX() / 4), Std.int(Config.getTextureResY() / 4));
 				Context.nodePreviewsWrap.set(MaterialParser.node_name(node), wimage);
-				// Crate render target for the mask
-				var mask = kha.Image.createRenderTarget(Std.int(Config.getTextureResX() / 4), Std.int(Config.getTextureResY() / 4));
-				Context.nodePreviewsWrap.set("mask_" + MaterialParser.node_name(node), mask);
-
 				MaterialParser.warp_passthrough = true;
 				RenderUtil.makeNodePreview(UINodes.inst.getCanvasMaterial(), node, wimage);
-				var nid = node.inputs[3].node_id;
-
-				// Search the previous mask node
-				var mask_node_id = -1;
-				for (lnk in UINodes.inst.getCanvasMaterial().links){
-					if (lnk.to_socket == 3 && lnk.to_id == nid){
-						mask_node_id = lnk.from_id;
-					}
-				}
-				var mask_node = null;
-				for (n in  UINodes.inst.getCanvasMaterial().nodes){
-					if (n.id == mask_node_id){
-						mask_node = n;
-					}
-				}
-				if (mask_node == null){
-					mask_node = node;
-				} 
-				RenderUtil.makeNodePreview(UINodes.inst.getCanvasMaterial(), mask_node, mask);
 				MaterialParser.warp_passthrough = false;
 			}
 		}

--- a/Sources/arm/node/MakeMaterial.hx
+++ b/Sources/arm/node/MakeMaterial.hx
@@ -181,7 +181,7 @@ class MakeMaterial {
 			Context.nodePreviewsBlur = null;
 		}
 		for (node in UINodes.inst.getCanvasMaterial().nodes) {
-			if (node.type == "BLUR") {
+			if (node.type == "BLUR" || node.type ==  "DIRECT_WARP") {
 				if (Context.nodePreviewsBlur == null) {
 					Context.nodePreviewsBlur = new Map();
 				}


### PR DESCRIPTION
Implemented the requested feature in #576. 
Resolves #576.
(Suppose to be similar to the same feature in other 3D painting apps, Hopefully right :D..)

The node is partially based on the baking mechanism of the Blur node.
Inputs are:
-  Color: the main texture to warp 
-  Strength (0.0 - 1.0): how much warp to apply
- Angle (degrees 0 - 360): the direction in which we apply the warp 
-  Mask: texture that represents the intensities of the warp for each pixel.

The effect is basically calculating the pixel with which we should replace the current pixel from the Color texture according to the other inputs.

Left side presents the effect applied to a square with a spherical grdient mask (Right side - strength == 0).
<img width="873" alt="warp_example" src="https://user-images.githubusercontent.com/15870496/94755245-87058700-039c-11eb-83ac-d5b96dae7e60.png">
