### PR TITLE
Fall back to English for untranslated words

### DIFF
--- a/Sources/arm/Translator.hx
+++ b/Sources/arm/Translator.hx
@@ -48,10 +48,10 @@ class Translator {
 			Config.raw.locale = "en";
 		}
 
+		// No translations to load, as source strings are in English.
+		// Clear existing translations if switching languages at runtime.
+		translations.clear();
 		if (Config.raw.locale == "en") {
-			// No translations to load, as source strings are in English.
-			// Clear existing translations if switching languages at runtime.
-			translations.clear();
 			return;
 		}
 


### PR DESCRIPTION
Switching to a language with a missing translation will fall back to English because the untranslated words will remain in the previous language.


An example of switching from German to Chinese

**after the fix**
![image](https://user-images.githubusercontent.com/1295639/97110976-7936ed80-171f-11eb-8c7e-c6a9d47fca60.png)

**before the fix**
![image](https://user-images.githubusercontent.com/1295639/97110982-7fc56500-171f-11eb-92e0-ca04be572333.png)
