### PR TITLE
Fix font_cjk.ttc url

### DIFF
--- a/Sources/arm/Translator.hx
+++ b/Sources/arm/Translator.hx
@@ -97,7 +97,7 @@ class Translator {
 			newFont = { path : "font_cjk.ttc", scale : 1.4 };
 			var cjkFontPath = Path.data() + Path.sep + newFont.path;
 			if (!File.exists(cjkFontPath)) {
-				File.download("https://github.com/armory3d/armorpaint/raw/master/Assets/common/font_cjk.ttc", cjkFontPath);
+				File.download("https://github.com/armory3d/armorpaint/raw/master/Assets/common/extra/font_cjk.ttc", cjkFontPath);
 			}
 			if (!File.exists(cjkFontPath)) {
 				// Fall back to English


### PR DESCRIPTION
Fixed the URL of the font_cjk.ttc file.
The current URL is here.
https://github.com/armory3d/armorpaint/blob/master/Assets/common/extra/font_cjk.ttc