### PR TITLE
Increase the width of the Japanese menu to prevent overlap

### DIFF
--- a/Sources/arm/Translator.hx
+++ b/Sources/arm/Translator.hx
@@ -126,6 +126,10 @@ class Translator {
 				var originFontSize = uis[0].t.FONT_SIZE;
 				// Scale up the font size a bit
 				uis[0].t.FONT_SIZE = Std.int(uis[0].t.FONT_SIZE * newFont.scale);
+				// Japanese has a lot of characters, so increase the width
+				if (Config.raw.locale == "ja") {
+					uis[0].t.ELEMENT_W = Std.int(App.theme.ELEMENT_W * newFont.scale);
+				}
 				for (ui in uis) {
 					ui.ops.font = f;
 					ui.setScale(ui.ops.scaleFactor);


### PR DESCRIPTION
fix #535 

**after the fix**
<image src="https://user-images.githubusercontent.com/1295639/103102015-8019a800-465d-11eb-9b59-6116af8db587.png" width="30%">

**before the fix**
<image src="https://user-images.githubusercontent.com/1295639/103102020-890a7980-465d-11eb-8a8f-2718113586b8.png" width="30%">
