### PR TITLE
Copied noise shader logic from Blender to apply in-scope color2

### DIFF
--- a/Libraries/shaderlib/Sources/arm/shader/ShaderFunctions.hx
+++ b/Libraries/shaderlib/Sources/arm/shader/ShaderFunctions.hx
@@ -157,12 +157,23 @@ float tex_magic_f(const vec3 p) {
 ";
 
 	public static var str_tex_brick = "
+float noise(int n) { /* fast integer noise */ 
+	int nn;
+	n = (n >> 13) ^ n;
+	nn = (n * (n * n * 60493 + 19990303) + 1376312589) & 0x7fffffff;
+	return 0.5f * float(nn) / 1073741824.0;
+}
 vec3 tex_brick(vec3 p, const vec3 c1, const vec3 c2, const vec3 c3) {
-	p /= vec3(0.9, 0.49, 0.49) / 2;
+	vec3 brickSize = vec3(0.9, 0.49, 0.49);
+	vec3 mortarSize = vec3(0.05, 0.1, 0.1);
+	p /= brickSize / 2;
 	if (fract(p.y * 0.5) > 0.5) p.x += 0.5;
+	float col = floor(p.x / (brickSize.x + (mortarSize.x * 2.0)));
+	float row = p.y;
 	p = fract(p);
-	vec3 b = step(p, vec3(0.95, 0.9, 0.9));
-	return mix(c3, c1, b.x * b.y * b.z);
+	vec3 b = step(p, 1.0 - mortarSize);
+	float tint = min(max(noise((int(col) << 16) + (int(row) & 0xFFFF)), 0.0), 1.0);
+	return mix(c3, mix(c1, c2, tint), b.x * b.y * b.z);
 }
 float tex_brick_f(vec3 p) {
 	p /= vec3(0.9, 0.49, 0.49) / 2;


### PR DESCRIPTION
Regarding my prior raised issue https://github.com/armory3d/armorpaint/issues/743

This is what the brick texture looks like with this change:

![image](https://user-images.githubusercontent.com/106222/103434046-d97f5b00-4bb8-11eb-98f3-b90a3cc5ebf1.png)

It could still go a ways further to meet/match the Blender implementation (source linked in my issue above), but at least people won't feel it's completely broken.

- I took care to ensure the brick pattern remains the same as before (in dimensions and scale) so that only the colors change, for backward compatibility.
- I took care to ensure the `Fac` output did not require modification.

Hope this helps!