### PR TITLE
Brush math node: fix Absolute bug and add missing operations

### DIFF
--- a/Sources/arm/node/NodesBrush.hx
+++ b/Sources/arm/node/NodesBrush.hx
@@ -465,7 +465,7 @@ class NodesBrush {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: ["Add", "Subtract", "Average", "Dot Product", "Cross Product", "Normalize"],
+						data: ["Add", "Subtract", "Average", "Dot Product", "Cross Product", "Normalize", "Multiply" ],
 						default_value: 0,
 						output: 0
 					}

--- a/Sources/arm/node/NodesBrush.hx
+++ b/Sources/arm/node/NodesBrush.hx
@@ -212,7 +212,7 @@ class NodesBrush {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: ["Add", "Subtract", "Multiply", "Divide", "Sine", "Cosine", "Tangent", "Arcsine", "Arccosine", "Arctangent", "Power", "Logarithm", "Minimum", "Maximum", "Round", "Less Than", "Greater Than", "Module", "Absolute"],
+						data: ["Add", "Subtract", "Multiply", "Divide", "Power", "Logarithm", "Square Root", "Absolute", "Minimum", "Maximum", "Less Than", "Greater Than", "Round", "Floor", "Ceil", "Fract", "Modulo", "Sine", "Cosine", "Tangent", "Arcsine", "Arccosine", "Arctangent", "Arctan2"],
 						default_value: 0,
 						output: 0
 					},

--- a/Sources/arm/node/brush/MathNode.hx
+++ b/Sources/arm/node/brush/MathNode.hx
@@ -28,12 +28,12 @@ class MathNode extends LogicNode {
 			f = Math.max(v1, v2);
 		case "Min":
 			f = Math.min(v1, v2);
-		case "Abs":
+		case "Absolute":
 			f = Math.abs(v1);
 		case "Subtract":
 			f = v1 - v2;
 		case "Divide":
-			f = v1 / v2;
+			f = v1 / (v2 == 0.0 ? 0.000001 : v2);
 		case "Tangent":
 			f = Math.tan(v1);
 		case "Arcsine":
@@ -42,18 +42,28 @@ class MathNode extends LogicNode {
 			f = Math.acos(v1);
 		case "Arctangent":
 			f = Math.atan(v1);
+		case "Arctan2":
+		    f = Math.atan2(v2,v1);
 		case "Power":
 			f = Math.pow(v1, v2);
 		case "Logarithm":
 			f = Math.log(v1);
 		case "Round":
 			f = Math.round(v1);
+		case "Floor":
+		    f = Math.floor(v1);
+		case "Ceil":
+		    f = Math.ceil(v1);
+		case "Fract":
+		    f = v1 - Math.floor(v1);
 		case "Less Than":
 			f = v1 < v2 ? 1.0 : 0.0;
 		case "Greater Than":
 			f = v1 > v2 ? 1.0 : 0.0;
 		case "Modulo":
 			f = v1 % v2;
+		case "Square Root":
+		    f = Math.sqrt(v1);
 		}
 
 		if (use_clamp) f = f < 0.0 ? 0.0 : (f > 1.0 ? 1.0 : f);


### PR DESCRIPTION
1. I had the problem that Absolute in brush math node did not work. So I looked into the code and saw the typo. I fixed it.
2. Modulo was called Module and did not work as well
3. I added all operations from the ordinary material math node, too (Square Root, Floor, Ceil , ...) AND arranged them in the same way to avoid confusion. 
4. I changed the behavior of Divide to match the material math node.


Finally one question not directly related to the pull request:
The convention for Atan2 is typically arctan2(y,x). The material math node calls the function with v2,v1 such that the node user has a x,y call convention for atan2. Is that intended because I would not expect that. (To be honest nobody will use the function anyway...)