### PR TITLE
Add length, distance, reflect, project, divide to vector math node

### DIFF
--- a/Sources/arm/node/NodesBrush.hx
+++ b/Sources/arm/node/NodesBrush.hx
@@ -465,7 +465,7 @@ class NodesBrush {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: ["Add", "Subtract", "Average", "Dot Product", "Cross Product", "Normalize", "Multiply" ],
+						data: ["Add", "Subtract", "Multiply", "Divide", "Average", "Dot Product", "Cross Product", "Normalize", "Project", "Reflect", "Length", "Distance" ],
 						default_value: 0,
 						output: 0
 					}

--- a/Sources/arm/node/brush/VectorMathNode.hx
+++ b/Sources/arm/node/brush/VectorMathNode.hx
@@ -38,6 +38,24 @@ class VectorMathNode extends LogicNode {
 			v.x *= v2.x;
 			v.y *= v2.y;
 			v.z *= v2.z;
+		case "Divide":
+			v.x /= v2.x == 0.0 ? 0.000001 : v2.x;
+			v.y /= v2.y == 0.0 ? 0.000001 : v2.y;
+			v.z /= v2.z == 0.0 ? 0.000001 : v2.z;
+		case "Length":
+			f = v.length();
+			v.set(f, f, f);
+		case "Distance":
+			f = v.distanceTo(v2);
+			v.set(f, f, f);
+		case "Project":
+			v.setFrom(v2);
+			v.mult(v1.dot(v2)/v2.dot(v2));
+		case "Reflect":
+			var tmp = new Vec4();
+			tmp.setFrom(v2);
+			tmp.normalize();
+			v.reflect(tmp);
 		}
 
 		if (from == 0) return v;


### PR DESCRIPTION
I added some missing but useful vector math operations. 
Please take at look at my reflect implementation. I'm not 100% sure whether I need the temporary variable or not. `v2.normalize()` would change v2 and 'm unsure whether this would have a global impact.