### PR TITLE
Add support for exporting DirectX normal maps

### DIFF
--- a/Assets/export_presets/unreal.json
+++ b/Assets/export_presets/unreal.json
@@ -1,7 +1,7 @@
 {
 	"textures": [
 		{ "name": "base", "channels": ["base_r", "base_g", "base_b", "1.0"], "color_space": "linear" },
-		{ "name": "nor", "channels": ["nor_r", "nor_g", "nor_b", "1.0"], "color_space": "linear" },
+		{ "name": "nor", "channels": ["nor_r", "nor_g_DirectX", "nor_b", "1.0"], "color_space": "linear" },
 		{ "name": "orm", "channels": ["occ", "rough", "metal", "1.0"], "color_space": "linear" }
 	]
 }

--- a/Sources/arm/io/ExportTexture.hx
+++ b/Sources/arm/io/ExportTexture.hx
@@ -260,7 +260,7 @@ class ExportTexture {
 		for (t in preset.textures) {
 			for (c in t.channels) {
 				if      ((c == "base_r" || c == "base_g" || c == "base_b" || c == "opac") && pixpaint == null) pixpaint = texpaint.getPixels();
-				else if ((c == "nor_r" || c == "nor_g" || c == "nor_b" || c == "emis" || c == "subs") && pixpaint_nor == null) pixpaint_nor = texpaint_nor.getPixels();
+				else if ((c == "nor_r" || c == "nor_g" || c == "nor_g_DirectX" || c == "nor_b" || c == "emis" || c == "subs") && pixpaint_nor == null) pixpaint_nor = texpaint_nor.getPixels();
 				else if ((c == "occ" || c == "rough" || c == "metal" || c == "height" || c == "smooth") && pixpaint_pack == null) pixpaint_pack = texpaint_pack.getPixels();
 			}
 		}
@@ -304,6 +304,7 @@ class ExportTexture {
 					else if (c == "metal") copyChannel(pixpaint_pack, 2, pix, i, t.color_space == "linear");
 					else if (c == "nor_r") copyChannel(pixpaint_nor, 0, pix, i, t.color_space == "linear");
 					else if (c == "nor_g") copyChannel(pixpaint_nor, 1, pix, i, t.color_space == "linear");
+					else if (c == "nor_g_DirectX") copyChannelInv(pixpaint_nor, 1, pix, i, t.color_space == "linear");
 					else if (c == "nor_b") copyChannel(pixpaint_nor, 2, pix, i, t.color_space == "linear");
 					else if (c == "occ") copyChannel(pixpaint_pack, 0, pix, i, t.color_space == "linear");
 					else if (c == "opac") copyChannel(pixpaint, 3, pix, i, t.color_space == "linear");

--- a/Sources/arm/ui/BoxExport.hx
+++ b/Sources/arm/ui/BoxExport.hx
@@ -17,7 +17,7 @@ class BoxExport {
 	public static var hpreset = Id.handle();
 	public static var files: Array<String> = null;
 	public static var preset: TExportPreset = null;
-	static var channels = ["base_r", "base_g", "base_b", "height", "metal", "nor_r", "nor_g", "nor_b", "occ", "opac", "rough", "smooth", "emis", "subs", "0.0", "1.0"];
+	static var channels = ["base_r", "base_g", "base_b", "height", "metal", "nor_r", "nor_g", "nor_g_DirectX", "nor_b", "occ", "opac", "rough", "smooth", "emis", "subs", "0.0", "1.0"];
 	static var colorSpaces = ["linear", "srgb"];
 
 	public static function showTextures() {


### PR DESCRIPTION
I think it is a good idea to be able to export normal maps as ordinary/OpenGl/Vulkan/Blender normal maps as well as DirectX style normal maps. As the first type is ArmorPaint's default I called the other one DirectX because it is the most prominent user of +Y normal maps and is imho the common terminology. And it is less confusing than +Y and -Y because I always mix them up. But please feel free to change the wording if you dislike it. 
I case you want to try it out:
DirectX-style bump
![directX_bump](https://user-images.githubusercontent.com/28649121/117064579-a72c6880-ad26-11eb-9a52-cd6aa555a6c1.png)
OpenGl-style bump
![opengl_bump](https://user-images.githubusercontent.com/28649121/117064581-a7c4ff00-ad26-11eb-979a-bd181c5931ec.png)

I also adapted the Unreal export preset because it uses the DirectX style normal maps. Unity uses OpenGL-style. I'm unsure about the others.