### PR TITLE
Reduce usage of system command

### DIFF
--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -400,7 +400,7 @@ class Project {
 					ImportMesh.run(path, clearLayers, replaceExisting);
 				}
 				if (ui.button(tr("?"))) {
-					File.explorer("https://github.com/armory3d/armorpaint_docs/blob/master/faq.md");
+					File.openInStdApp("https://github.com/armory3d/armorpaint_docs/blob/master/faq.md");
 				}
 			}
 		});

--- a/Sources/arm/node/NodesBrush.hx
+++ b/Sources/arm/node/NodesBrush.hx
@@ -212,7 +212,7 @@ class NodesBrush {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: ["Add", "Subtract", "Multiply", "Divide", "Power", "Logarithm", "Square Root", "Absolute", "Minimum", "Maximum", "Less Than", "Greater Than", "Round", "Floor", "Ceil", "Fract", "Modulo", "Sine", "Cosine", "Tangent", "Arcsine", "Arccosine", "Arctangent", "Arctan2"],
+						data: ["Add", "Subtract", "Multiply", "Divide", "Power", "Logarithm", "Square Root", "Absolute", "Minimum", "Maximum", "Less Than", "Greater Than", "Round", "Floor", "Ceil", "Fract", "Modulo", "Ping-Pong", "Sine", "Cosine", "Tangent", "Arcsine", "Arccosine", "Arctangent", "Arctan2"],
 						default_value: 0,
 						output: 0
 					},

--- a/Sources/arm/node/brush/MathNode.hx
+++ b/Sources/arm/node/brush/MathNode.hx
@@ -64,6 +64,8 @@ class MathNode extends LogicNode {
 			f = v1 % v2;
 		case "Square Root":
 		    f = Math.sqrt(v1);
+		case "Ping-Pong":
+		    f = (v2 != 0.0) ? v2 - Math.abs( (Math.abs(v1) % (2*v2)) - v2) : 0.0;
 		}
 
 		if (use_clamp) f = f < 0.0 ? 0.0 : (f > 1.0 ? 1.0 : f);

--- a/Sources/arm/ui/BoxPreferences.hx
+++ b/Sources/arm/ui/BoxPreferences.hx
@@ -331,7 +331,7 @@ class BoxPreferences {
 				ui.endElement();
 				ui.row([0.5]);
 				if (ui.button(tr("Help"))) {
-					File.explorer("https://github.com/armory3d/armorpaint_docs#pen");
+					File.openInStdApp("https://github.com/armory3d/armorpaint_docs#pen");
 				}
 			}
 
@@ -532,7 +532,7 @@ plugin.drawUI = function(ui) {
 							ui.text(f, Right, ui.t.HIGHLIGHT_COL);
 							var path = Path.data() + Path.sep + "plugins" + Path.sep + f;
 							if (ui.button(tr("Edit in Text Editor"), Left)) {
-								File.start(path);
+								File.openInStdApp(path);
 							}
 							if (ui.button(tr("Edit in Script Tab"), Left)) {
 								iron.data.Data.getBlob("plugins/" + f, function(blob: kha.Blob) {

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -139,7 +139,7 @@ class TabTextures {
 									for (b in Project.brushes) updateTexturePointers(b.canvas.nodes, i);
 								}
 								if (ui.button(tr("Open Containing Directory..."), Left)) {
-									File.explorer(asset.file.substr(0, asset.file.lastIndexOf(Path.sep)));
+									File.openInStdApp(asset.file.substr(0, asset.file.lastIndexOf(Path.sep)));
 								}
 							}, 6);
 						}

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -320,21 +320,21 @@ class UIMenu {
 			}
 			else if (menuCategory == MenuHelp) {
 				if (menuButton(ui, tr("Manual"))) {
-					File.explorer("https://armorpaint.org/manual");
+					File.openInStdApp("https://armorpaint.org/manual");
 				}
 				if (menuButton(ui, tr("What's New"))) {
-					File.explorer("https://armorpaint.org/notes");
+					File.openInStdApp("https://armorpaint.org/notes");
 				}
 				if (menuButton(ui, tr("Issue Tracker"))) {
-					File.explorer("https://github.com/armory3d/armorpaint/issues");
+					File.openInStdApp("https://github.com/armory3d/armorpaint/issues");
 				}
 				if (menuButton(ui, tr("Report Bug"))) {
 					var url = "https://github.com/armory3d/armorpaint/issues/new?labels=bug&template=bug_report.md&body=*ArmorPaint%20" + Main.version + "-" + Main.sha + ",%20" + System.systemId + "*%0A%0A**Issue description:**%0A%0A**Steps to reproduce:**%0A%0A";
-					File.explorer(url);
+					File.openInStdApp(url);
 				}
 				if (menuButton(ui, tr("Request Feature"))) {
 					var url = "https://github.com/armory3d/armorpaint/issues/new?labels=feature%20request&template=feature_request.md&body=*ArmorPaint%20" + Main.version + "-" + Main.sha + ",%20" + System.systemId + "*%0A%0A**Feature description:**%0A%0A";
-					File.explorer(url);
+					File.openInStdApp(url);
 				}
 				menuSeparator(ui);
 


### PR DESCRIPTION
I have made a proposal for reducing the usage of "system".
What I did is essentially:

1. Replace unnecessary "system"-calls by their function equivalents: e.g. system("mkdir ...") to mkdir. To achieve this I created c++ implementations in main.cpp and wired them to javascript/Haxe functions. 
2. The platform dependent code is now completely implemented in armorcore's C/C++ part. 
3. I merged the start and the explorer function as I could not see any significant difference. I might have overlooked something.

Limitations/possible issues:
**I could not test the code on all platforms**. There might be some smaller issues.

Future:
1. Windows implemented proper utf8 handling in Win10 1903. We could switch ArmorPaint to use the utf8 locale in the future (it is basically just a compiler flag). By doing this we would get rid of all these utf8 to ucs16 conversions. 
2. If you eventually switch to C++17 we could also use the new filesystem API. It is platform independent and this way we could get rid of most platform dependent file handling. Every function has non-throwing versions, too. I.e. we could avoid issues with exceptions as well.

I know the code is not perfect yet and we have to tweak it a bit for sure.