### PR TITLE
Add missing operations to brush math and vector math node

### DIFF
--- a/Sources/arm/node/NodesBrush.hx
+++ b/Sources/arm/node/NodesBrush.hx
@@ -214,7 +214,7 @@ class NodesBrush {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: ["Add", "Subtract", "Multiply", "Divide", "Power", "Logarithm", "Square Root", "Absolute", "Minimum", "Maximum", "Less Than", "Greater Than", "Round", "Floor", "Ceil", "Fract", "Modulo", "Ping-Pong", "Sine", "Cosine", "Tangent", "Arcsine", "Arccosine", "Arctangent", "Arctan2"],
+						data: ["Add", "Subtract", "Multiply", "Divide", "Power", "Logarithm", "Square Root", "Inverse Square Root", "Absolute", "Exponent", "Minimum", "Maximum", "Less Than", "Greater Than", "Sign", "Round", "Floor", "Ceil", "Truncate", "Fraction", "Modulo", "Snap", "Ping-Pong", "Sine", "Cosine", "Tangent", "Arcsine", "Arccosine", "Arctangent", "Arctan2", "Hyperbolic Sine", "Hyperbolic Cosine", "Hyperbolic Tangent", "To Radians", "To Degrees"],
 						default_value: 0,
 						output: 0
 					},
@@ -467,7 +467,7 @@ class NodesBrush {
 					{
 						name: _tr("operation"),
 						type: "ENUM",
-						data: ["Add", "Subtract", "Multiply", "Divide", "Average", "Dot Product", "Cross Product", "Normalize", "Project", "Reflect", "Length", "Distance"],
+						data: ["Add", "Subtract", "Multiply", "Divide", "Average", "Cross Product", "Project", "Reflect", "Dot Product", "Distance", "Length", "Scale", "Normalize", "Absolute", "Minimum", "Maximum", "Floor", "Ceil", "Fraction", "Modulo", "Snap", "Sine", "Cosine", "Tangent"],
 						default_value: 0,
 						output: 0
 					}

--- a/Sources/arm/node/brush/MathNode.hx
+++ b/Sources/arm/node/brush/MathNode.hx
@@ -54,7 +54,9 @@ class MathNode extends LogicNode {
 		    f = Math.floor(v1);
 		case "Ceil":
 		    f = Math.ceil(v1);
-		case "Fract":
+		case "Truncate":
+			f = Math.ffloor(v1);
+		case "Fraction":
 		    f = v1 - Math.floor(v1);
 		case "Less Than":
 			f = v1 < v2 ? 1.0 : 0.0;
@@ -62,10 +64,28 @@ class MathNode extends LogicNode {
 			f = v1 > v2 ? 1.0 : 0.0;
 		case "Modulo":
 			f = v1 % v2;
+		case "Snap":
+			f = Math.floor(v1 / v2) * v2;
 		case "Square Root":
 		    f = Math.sqrt(v1);
+		case "Inverse Square Root":
+			f = 1.0 / Math.sqrt(v1);
+		case "Exponent":
+			f = Math.exp(v1);
+		case "Sign":
+			f = v1 > 0 ? 1.0 : (v1 < 0 ? -1.0 : 0);
 		case "Ping-Pong":
 		    f = (v2 != 0.0) ? v2 - Math.abs((Math.abs(v1) % (2 * v2)) - v2) : 0.0;
+		case "Hyperbolic Sine":
+			f = (Math.exp(v1) - Math.exp(-v1)) / 2.0;
+		case "Hyperbolic Cosine":
+			f = (Math.exp(v1) + Math.exp(-v1)) / 2.0;
+		case "Hyperbolic Tangent":
+			f = 1.0 - (2.0 / (Math.exp(2*v1) + 1));
+		case "To Radians":
+			f = v1 / 180.0 * Math.PI;
+		case "To Degrees":
+			f = v1 / Math.PI * 180.0;
 		}
 
 		if (use_clamp) f = f < 0.0 ? 0.0 : (f > 1.0 ? 1.0 : f);

--- a/Sources/arm/node/brush/VectorMathNode.hx
+++ b/Sources/arm/node/brush/VectorMathNode.hx
@@ -56,6 +56,54 @@ class VectorMathNode extends LogicNode {
 				tmp.setFrom(v2);
 				tmp.normalize();
 				v.reflect(tmp);
+			case "Scale":
+				v.x *= v2.x;
+				v.y *= v2.x;
+				v.z *= v2.x;
+			case "Absolute":
+				v.x = Math.abs(v.x);
+				v.y = Math.abs(v.y);
+				v.z = Math.abs(v.z);
+			case "Minimum":
+				v.x = Math.min(v1.x,v2.x);
+				v.y = Math.min(v1.y,v2.y);
+				v.z = Math.min(v1.z,v2.z);
+			case "Maximum":
+				v.x = Math.max(v1.x,v2.x);
+				v.y = Math.max(v1.y,v2.y);
+				v.z = Math.max(v1.z,v2.z);
+			case "Floor": 
+				v.x = Math.floor(v1.x);
+				v.y = Math.floor(v1.y);
+				v.z = Math.floor(v1.z);
+			case "Ceil":
+				v.x = Math.ceil(v1.x);
+				v.y = Math.ceil(v1.y);
+				v.z = Math.ceil(v1.z);
+			case "Fraction":
+				v.x = v1.x - Math.floor(v1.x);
+				v.y = v1.y - Math.floor(v1.y);
+				v.z = v1.z - Math.floor(v1.z);
+			case "Modulo":
+				v.x = v1.x % v2.x;
+				v.y = v1.y % v2.y;
+				v.z = v1.z % v2.z;
+			case "Snap":
+				v.x = Math.floor(v1.x / v2.x) * v2.x;
+				v.y = Math.floor(v1.y / v2.y) * v2.y;
+				v.z = Math.floor(v1.z / v2.z) * v2.z;
+			case "Sine":
+				v.x = Math.sin(v1.x);
+				v.y = Math.sin(v1.y);
+				v.z = Math.sin(v1.z);
+			case "Cosine":
+				v.x = Math.cos(v1.x);
+				v.y = Math.cos(v1.y);
+				v.z = Math.cos(v1.z);
+			case "Tangent":
+				v.x = Math.tan(v1.x);
+				v.y = Math.tan(v1.y);
+				v.z = Math.tan(v1.z);
 		}
 
 		if (from == 0) return v;


### PR DESCRIPTION
Currently the brush math and vector math nodes lack operations compared to the corresponding material nodes. This pr aligns both again such that they allow for the same operations.
Unfortunately the haxe math library does not offer hyperbolic functions. The js.math module would implement them, but I could not find any usage of javascript only modules. Therefore I implemented them by hand using the exp function. 