### PR TITLE
Improve layer merge down

### DIFF
--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -365,21 +365,73 @@ class Layers {
 		}
 	}
 
-	public static function mergeDown() {
-		var l1 = Context.layer;
+	public static function applyMasks(l : LayerSlot) {
+		var masks = l.getMasks();
 
-		// Apply masks
-		var masks = l1.getMasks();
 		if (masks != null) {
 			for (i in 0...masks.length - 1) {
 				mergeLayer(masks[i + 1], masks[i]);
 				masks[i].delete();
 			}
 			masks[masks.length - 1].applyMask();
+			Context.layerPreviewDirty = true;
+		}
+	}
+
+	public static function mergeDown() {
+		var l1 = Context.layer;
+
+		if (l1.isGroup()) {
+			var children = l1.getChildren();
+
+			if (children.length == 1 && children[0].hasMasks()) {
+				applyMasks(children[0]);
+			}
+
+			for (i in 0...children.length - 1) {
+				Context.setLayer(children[children.length - 1 - i]);
+				mergeDown();
+			}
+		
+			children[0].parent = null;
+			children[0].name = l1.name;
+			if (children[0].fill_layer != null) children[0].toPaintLayer();
+			l1.delete();
+			l1 = children[0];
+			Context.setLayer(l1);
+		}
+		if(l1.hasMasks()) {
+			applyMasks(l1);
 			Context.setLayer(l1);
 		}
 
 		var l0 = Project.layers[Project.layers.indexOf(l1) - 1];
+
+		if (l0.isGroup()) {
+			var children = l0.getChildren();
+
+			if (children.length == 1 && children[0].hasMasks()) {
+				applyMasks(children[0]);
+			}
+
+			for (i in 0...children.length - 1) {
+				Context.setLayer(children[children.length - 1 - i]);
+				mergeDown();
+			}
+		
+			children[0].parent = null;
+			children[0].name = l0.name;
+			if (children[0].fill_layer != null) children[0].toPaintLayer();
+			l0.delete();
+			l0 = children[0];
+			Context.setLayer(l1);
+		}
+		else if(l0.hasMasks())
+		{
+			applyMasks(l0);
+			Context.setLayer(l1);
+		}
+
 		mergeLayer(l0, l1);
 
 		Context.layer.delete();

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -384,6 +384,15 @@ class LayerSlot {
 		return children;
 	}
 
+	public function hasMasks(): Bool {
+		for (l in Project.layers) {
+			if (l.parent == this && l.isMask()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public function getOpacity(): Float {
 		var f = maskOpacity;
 		if (isLayer() && parent != null) f *= parent.maskOpacity;


### PR DESCRIPTION
This PR improves the merge down functionality for layers and fixes a few merge down related bugs.

My assumption was: Merge down must not change the visual appearance. This assumption leads to the following features that are - to my best knowledge - compatible to other common software that supports layers.

1. Now the layer system allows for merging down layers with masks to layers with masks in a correct fashion. First the masks of both layers are applied, then the results are merged.
2. Layers can be merged down on groups. In order to do that the group is merged first, then the two layers are merged.
3. Groups can be merged down on a layer.
4. Groups can be merged down on groups.
5. Now groups having only one child which has a mask are correctly merged. (Was a bug)

This fixes #1008 and partially also #991.
Limitations: I have not implemented the undo features as I thought it is best to fix them all together.

