### PR TITLE
Fix #1013 and a merge down bug

### DIFF
--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -430,6 +430,7 @@ class LayerSlot {
 		var kParent = k < Project.layers.length ? Project.layers[k].parent : null;
 		var kIsGroup = k < Project.layers.length ? Project.layers[k].isGroup() : false;
 		var kIsMask = k < Project.layers.length ? Project.layers[k].isMask() : false;
+		var jIsMask = j < Project.layers.length ? Project.layers[j].isMask() : false;
 		var kIsLayer = k < Project.layers.length ? Project.layers[k].isLayer() : false;
 		var kLayer = k < Project.layers.length ? Project.layers[k] : null;
 
@@ -455,6 +456,11 @@ class LayerSlot {
 
 		// Prevent moving layer to mask
 		if (isLayer && kIsMask) {
+			return;
+		}
+
+		// Prevent moving layer between layer and mask
+		if (isLayer && jIsMask) {
 			return;
 		}
 

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -474,7 +474,7 @@ class TabLayers {
 				firstGroup = false;
 			}
 		}
-		if (firstGroup) canMergeDown = false;
+		if (l.isGroup() && firstGroup) canMergeDown = false;
 
 		if (l.fill_layer == null) add += 1; // Clear
 		if (l.fill_layer != null && !l.isMask()) add += 3;


### PR DESCRIPTION
This pull request fixes two bugs

1. Prevent drag layer between layer and its mask fixes #1013. 
2. Fixes a bug introduced by myself. Due to the newly introduced mechanic to detect that a group is the last group on the layer stack I forgot to check whether this layer is actually a group and not an ordinary layer. Sorry for that.