### PR TITLE
Allow multiple file selection

### DIFF
--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -55,7 +55,7 @@ class Project {
 	static var meshList: Array<String> = null;
 
 	public static function projectOpen() {
-		UIFiles.show("arm", false, function(path: String) {
+		UIFiles.show("arm", false, false, function(path: String) {
 			if (!path.endsWith(".arm")) {
 				Console.error(Strings.error0());
 				return;
@@ -116,7 +116,7 @@ class Project {
 	}
 
 	public static function projectSaveAs() {
-		UIFiles.show("arm", true, function(path: String) {
+		UIFiles.show("arm", true,false, function(path: String) {
 			var f = UIFiles.filename;
 			if (f == "") f = tr("untitled");
 			filepath = path + Path.sep + f;
@@ -300,7 +300,7 @@ class Project {
 	}
 
 	public static function importMaterial() {
-		UIFiles.show("arm,blend", false, function(path: String) {
+		UIFiles.show("arm,blend", false, true, function(path: String) {
 			path.endsWith(".blend") ?
 				ImportBlend.runMaterial(path) :
 				ImportArm.runMaterial(path);
@@ -308,7 +308,7 @@ class Project {
 	}
 
 	public static function importBrush() {
-		UIFiles.show("arm," + Path.textureFormats.join(","), false, function(path: String) {
+		UIFiles.show("arm," + Path.textureFormats.join(","), false, true, function(path: String) {
 			// Create brush from texture
 			if (Path.isTexture(path)) {
 				// Import texture
@@ -355,7 +355,7 @@ class Project {
 	}
 
 	public static function importMesh(replaceExisting = true) {
-		UIFiles.show(Path.meshFormats.join(","), false, function(path: String) {
+		UIFiles.show(Path.meshFormats.join(","), false, false, function(path: String) {
 			importMeshBox(path, replaceExisting);
 		});
 	}
@@ -416,13 +416,13 @@ class Project {
 
 	public static function importAsset(filters: String = null, hdrAsEnvmap = true) {
 		if (filters == null) filters = Path.textureFormats.join(",") + "," + Path.meshFormats.join(",");
-		UIFiles.show(filters, false, function(path: String) {
+		UIFiles.show(filters, false, true, function(path: String) {
 			ImportAsset.run(path, -1.0, -1.0, true, hdrAsEnvmap);
 		});
 	}
 
 	public static function importSwatches() {
-		UIFiles.show("arm", false, function(path: String) {
+		UIFiles.show("arm", false, false, function(path: String) {
 			ImportArm.runSwatches(path);
 		});
 	}
@@ -453,7 +453,7 @@ class Project {
 		}
 		if (!File.exists(asset.file)) {
 			var filters = Path.textureFormats.join(",");
-			UIFiles.show(filters, false, function(path: String) {
+			UIFiles.show(filters, false, false, function(path: String) {
 				load(path);
 			});
 		}
@@ -497,7 +497,7 @@ class Project {
 	}
 
 	public static function exportSwatches() {
-		UIFiles.show("arm", true, function(path: String) {
+		UIFiles.show("arm", true, false, function(path: String) {
 			var f = UIFiles.filename;
 			if (f == "") f = tr("untitled");
 			ExportArm.runSwatches(path + Path.sep + f);

--- a/Sources/arm/ui/BoxExport.hx
+++ b/Sources/arm/ui/BoxExport.hx
@@ -99,7 +99,7 @@ class BoxExport {
 			if (ui.button(tr("Export"))) {
 				UIBox.show = false;
 				var filters = App.bitsHandle.position != Bits8 ? "exr" : Context.formatType == FormatPng ? "png" : "jpg";
-				UIFiles.show(filters, true, function(path: String) {
+				UIFiles.show(filters, true, false, function(path: String) {
 					Context.textureExportPath = path;
 					function _init() {
 						ExportTexture.run(path, bakeMaterial);
@@ -137,7 +137,7 @@ class BoxExport {
 			}
 
 			if (ui.button(tr("Import"))) {
-				UIFiles.show("json", false, function(path: String) {
+				UIFiles.show("json", false, false, function(path: String) {
 					path = path.toLowerCase();
 					if (path.endsWith(".json")) {
 						var filename = path.substr(path.lastIndexOf(Path.sep) + 1);
@@ -264,7 +264,7 @@ class BoxExport {
 				}
 				if (ui.button(tr("Export"))) {
 					UIBox.show = false;
-					UIFiles.show(Context.exportMeshFormat == FormatObj ? "obj" : "arm", true, function(path: String) {
+					UIFiles.show(Context.exportMeshFormat == FormatObj ? "obj" : "arm", true, false, function(path: String) {
 						var f = UIFiles.filename;
 						if (f == "") f = tr("untitled");
 						ExportMesh.run(path + Path.sep + f, applyDisplacement);
@@ -290,7 +290,7 @@ class BoxExport {
 				}
 				if (ui.button(tr("Export"))) {
 					UIBox.show = false;
-					UIFiles.show("arm", true, function(path: String) {
+					UIFiles.show("arm", true, false, function(path: String) {
 						var f = UIFiles.filename;
 						if (f == "") f = tr("untitled");
 						iron.App.notifyOnInit(function() {
@@ -318,7 +318,7 @@ class BoxExport {
 				}
 				if (ui.button(tr("Export"))) {
 					UIBox.show = false;
-					UIFiles.show("arm", true, function(path: String) {
+					UIFiles.show("arm", true, false, function(path: String) {
 						var f = UIFiles.filename;
 						if (f == "") f = tr("untitled");
 						iron.App.notifyOnInit(function() {

--- a/Sources/arm/ui/BoxPreferences.hx
+++ b/Sources/arm/ui/BoxPreferences.hx
@@ -100,7 +100,7 @@ class BoxPreferences {
 							});
 						}
 						if (ui.button(tr("Import..."), Left)) {
-							UIFiles.show("arm", false, function(path: String) {
+							UIFiles.show("arm", false, false, function(path: String) {
 								Data.getBlob(path, function(b: kha.Blob) {
 									var raw = Json.parse(b.toString());
 									iron.App.notifyOnInit(function() {
@@ -165,13 +165,13 @@ class BoxPreferences {
 				}
 
 				if (ui.button(tr("Import"))) {
-					UIFiles.show("json", false, function(path: String) {
+					UIFiles.show("json", false, false, function(path: String) {
 						ImportTheme.run(path);
 					});
 				}
 
 				if (ui.button(tr("Export"))) {
-					UIFiles.show("json", true, function(path) {
+					UIFiles.show("json", true, false, function(path) {
 						path += Path.sep + UIFiles.filename;
 						if (!path.endsWith(".json")) path += ".json";
 						Krom.fileSaveBytes(path, Bytes.ofString(Json.stringify(arm.App.theme)).getData());
@@ -453,12 +453,12 @@ class BoxPreferences {
 				}
 
 				if (ui.button(tr("Import"))) {
-					UIFiles.show("json", false, function(path: String) {
+					UIFiles.show("json", false, false, function(path: String) {
 						ImportKeymap.run(path);
 					});
 				}
 				if (ui.button(tr("Export"))) {
-					UIFiles.show("json", true, function(dest: String) {
+					UIFiles.show("json", true, false, function(dest: String) {
 						if (!UIFiles.filename.endsWith(".json")) UIFiles.filename += ".json";
 						var path = Path.data() + Path.sep + "keymap_presets" + Path.sep + Config.raw.keymap;
 						File.copy(path, dest + Path.sep + UIFiles.filename);
@@ -515,7 +515,7 @@ plugin.drawUI = function(ui) {
 					});
 				}
 				if (ui.button(tr("Import"))) {
-					UIFiles.show("js,wasm,zip", false, function(path: String) {
+					UIFiles.show("js,wasm,zip", false, false, function(path: String) {
 						ImportPlugin.run(path);
 					});
 				}
@@ -555,7 +555,7 @@ plugin.drawUI = function(ui) {
 
 							}
 							if (ui.button(tr("Export"), Left)) {
-								UIFiles.show("js", true, function(dest: String) {
+								UIFiles.show("js", true, false, function(dest: String) {
 									if (!UIFiles.filename.endsWith(".js")) UIFiles.filename += ".js";
 									File.copy(path, dest + Path.sep + UIFiles.filename);
 								});

--- a/Sources/arm/ui/TabConsole.hx
+++ b/Sources/arm/ui/TabConsole.hx
@@ -27,7 +27,7 @@ class TabConsole {
 			}
 			if (ui.button(tr("Export"))) {
 				var str = Console.lastTraces.join("\n");
-				UIFiles.show("txt", true, function(path: String) {
+				UIFiles.show("txt", true, false, function(path: String) {
 					var f = UIFiles.filename;
 					if (f == "") f = tr("untitled");
 					path = path + Path.sep + f;

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -493,7 +493,7 @@ class TabLayers {
 
 			if (ui.button(tr("Export"), Left)) {
 				if (l.isMask()) {
-					UIFiles.show("png", true, function(path: String) {
+					UIFiles.show("png", true, false, function(path: String) {
 						var f = UIFiles.filename;
 						if (f == "") f = tr("untitled");
 						if (!f.endsWith(".png")) f += ".png";

--- a/Sources/arm/ui/TabScript.hx
+++ b/Sources/arm/ui/TabScript.hx
@@ -34,7 +34,7 @@ class TabScript {
 				hscript.text = "";
 			}
 			if (ui.button(tr("Import"))) {
-				UIFiles.show("js", false, function(path: String) {
+				UIFiles.show("js", false, false, function(path: String) {
 					Data.getBlob(path, function(b: Blob) {
 						hscript.text = b.toString();
 						Data.deleteBlob(path);
@@ -43,7 +43,7 @@ class TabScript {
 			}
 			if (ui.button(tr("Export"))) {
 				var str = hscript.text;
-				UIFiles.show("js", true, function(path: String) {
+				UIFiles.show("js", true, false, function(path: String) {
 					var f = UIFiles.filename;
 					if (f == "") f = tr("untitled");
 					path = path + Path.sep + f;

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -22,7 +22,7 @@ class TabTextures {
 			ui.row([1 / 4, 1 / 4]);
 
 			if (ui.button(tr("Import"))) {
-				UIFiles.show(Path.textureFormats.join(","), false, function(path: String) {
+				UIFiles.show(Path.textureFormats.join(","), false, true, function(path: String) {
 					ImportAsset.run(path, -1.0, -1.0, true, false);
 				});
 			}
@@ -94,7 +94,7 @@ class TabTextures {
 							UIMenu.draw(function(ui: Zui) {
 								ui.text(asset.name + (isPacked ? " " + tr("(packed)") : ""), Right, ui.t.HIGHLIGHT_COL);
 								if (ui.button(tr("Export"), Left)) {
-									UIFiles.show("png", true, function(path: String) {
+									UIFiles.show("png", true, false, function(path: String) {
 										App.notifyOnNextFrame(function () {
 											if (Layers.pipeMerge == null) Layers.makePipe();
 											var target = kha.Image.createRenderTarget(to_pow2(img.width), to_pow2(img.height));

--- a/Sources/arm/ui/UIFiles.hx
+++ b/Sources/arm/ui/UIFiles.hx
@@ -22,7 +22,7 @@ class UIFiles {
 	static var showExtensions = false;
 	static var offline = false;
 
-	public static function show(filters: String, isSave: Bool, filesDone: String->Void) {
+	public static function show(filters: String, isSave: Bool, openMultiple : Bool, filesDone: String->Void) {
 
 		#if krom_android
 		if (isSave) {
@@ -32,14 +32,28 @@ class UIFiles {
 		else {
 		#end
 
-		path = isSave ? Krom.saveDialog(filters, "") : Krom.openDialog(filters, "");
-		if (path != null) {
-			while (path.indexOf(Path.sep + Path.sep) >= 0) path = path.replace(Path.sep + Path.sep, Path.sep);
-			path = path.replace("\r", "");
-			filename = path.substr(path.lastIndexOf(Path.sep) + 1);
-			if (isSave) path = path.substr(0, path.lastIndexOf(Path.sep));
-			filesDone(path);
+		if (isSave) {
+			path = Krom.saveDialog(filters, "");
+			if (path != null) {
+				while (path.indexOf(Path.sep + Path.sep) >= 0) path = path.replace(Path.sep + Path.sep, Path.sep);
+				path = path.replace("\r", "");
+				filename = path.substr(path.lastIndexOf(Path.sep) + 1);
+				path = path.substr(0, path.lastIndexOf(Path.sep));
+				filesDone(path);
+			}
 		}
+		else {
+			var paths = Krom.openDialog(filters, "", openMultiple);
+			if (paths != null && paths.length > 0) {
+				for (path in paths) {
+					while (path.indexOf(Path.sep + Path.sep) >= 0) path = path.replace(Path.sep + Path.sep, Path.sep);
+					path = path.replace("\r", "");
+					filename = path.substr(path.lastIndexOf(Path.sep) + 1);
+					filesDone(path); 
+				}
+			}
+		}
+	
 		releaseKeys();
 
 		#if krom_android

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -62,7 +62,7 @@ class UIMenu {
 				menuSeparator(ui);
 				if (menuButton(ui, tr("Import Texture..."), Config.keymap.file_import_assets)) Project.importAsset(Path.textureFormats.join(","), false);
 				if (menuButton(ui, tr("Import Envmap..."))) {
-					UIFiles.show("hdr", false, function(path: String) {
+					UIFiles.show("hdr", false, false, function(path: String) {
 						if (!path.endsWith(".hdr")) {
 							Console.error("Error: .hdr file expected");
 							return;


### PR DESCRIPTION
Loading multiple textures, fonts, ... is somewhat painful using the open file dialog because it does not allow for selecting multiple files. This pull request changes that and allows for selecting multiple files where appropriate.
The native part is implemented in https://github.com/armory3d/armorcore/pull/29 
The key part of this PR is the extension of UIFiles.show. It adds a new paramter `openMultiple` that enables multi-selection. I'm not completely sure whether this kind of extension is the best solution. Maybe it would make sense to split open and save dialogs in separate methods.