### PR TITLE
Add wireframe option to fill tool

### DIFF
--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -282,6 +282,14 @@ class UIHeader {
 						MakeMaterial.parsePaintMaterial();
 						MakeMaterial.parseMeshMaterial();
 					}
+
+					Context.drawWireframe = ui.check(Context.wireframeHandle, " " + tr("Wireframe"));
+					if (Context.wireframeHandle.changed) {
+						ui.g.end();
+						UVUtil.cacheUVMap();
+						ui.g.begin(false);
+						MakeMaterial.parseMeshMaterial();
+					}
 				}
 				else {
 					var _w = ui._w;


### PR DESCRIPTION
I added an option to enable/disable wireframe in the fill tool. The idea was proposed by @Wario-Ametrano in https://github.com/armory3d/armorpaint/issues/1069#issuecomment-889419349 