### PR TITLE
Improve graphics card output on windows

### DIFF
--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -394,12 +394,20 @@ class UIMenu {
 					var save = (Path.isProtected() ? Krom.savePath() : Path.data()) + Path.sep + "tmp.txt";
 					Krom.sysCommand('wmic path win32_VideoController get name > "' + save + '"');
 					var bytes = haxe.io.Bytes.ofData(Krom.loadBlob(save));
-					var gpu = "";
-					for (i in 30...Std.int(bytes.length / 2)) {
+					var gpuRaw = "";
+					for (i in 0...Std.int(bytes.length / 2)) {
 						var c = String.fromCharCode(bytes.get(i * 2));
-						if (c == "\n") continue;
-						gpu += c;
+						gpuRaw += c;
 					}
+
+					var gpus = gpuRaw.split("\n");
+					gpus = gpus.splice(1,gpus.length-2);
+					var gpu = "";
+					for (g in gpus) {
+						gpu += g.rtrim() + ", ";
+					}
+					gpu = gpu.substr(0,gpu.length-2);
+
 					msg += '\n$gpu';
 					#else
 					// { lshw -C display }


### PR DESCRIPTION
Currently ArmorPaint has issues showing the graphics cards.
The previous code assumed that there are always 30 leading bytes. This assumption is false. I checked it on different maschines. Sometimes it was less (therefore there were leading white spaces), sometimes it was more (therefore the NVID part of NVIDIA was missing in some cases).
Further more the code had problems with multiple graphics cards. Now the message should be nice and clean. 