### PR TITLE
Duplicate for swatches

### DIFF
--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -102,14 +102,19 @@ class TabSwatches {
 					}
 					if (ui.isHovered && ui.inputReleasedR) {
 						Context.setSwatch(Project.raw.swatches[i]);
-						var add = Project.raw.swatches.length > 1 ? 1 : 0;
+						var add = Project.raw.swatches.length > 1 ? 2 : 1;
 						UIMenu.draw(function(ui: Zui) {
 							ui.text(tr("Swatch"), Right, ui.t.HIGHLIGHT_COL);
-							if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left)) {
+							if (ui.button(tr("Duplicate"), Left)) {
+								Context.setSwatch(Project.makeSwatch(Context.swatch.base));
+								Project.raw.swatches.push(Context.swatch);
+							}
+							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left)) {
 								Context.setSwatch(Project.raw.swatches[i == 0 ? 1 : 0]);
 								Project.raw.swatches.splice(i, 1);
 								UIStatus.inst.statusHandle.redraws = 2;
 							}
+							
 						}, 1 + add);
 					}
 					if (ui.isHovered) {


### PR DESCRIPTION
Color palettes are often created by starting with a base color and adding lighter and darker tones afterwards. The duplicate function for swatches makes this simpler.

Finally I have a question, too. Locally I also added an option to copy the hex color code to clipboard. To do that I exposed the `kinc_copy_to_clipboard` via a newly created function `krom_copy_to_clipboard` and used this one to achieve the desired result. Having done that I also had the idea to add a copy button to the about dialog (more precisely to the `UIBox `in case it is on linux,windows or mac and the text is copyable). The idea was to simplify reporting details (ArmorPaint version + OS/device)
![grafik](https://user-images.githubusercontent.com/28649121/131996199-89b7601d-0851-42c9-8137-40b2cc3983be.png) 
Are you interested in one of these two enhancements?
