### PR TITLE
Copy texts at various places

### DIFF
--- a/Sources/arm/ui/TabConsole.hx
+++ b/Sources/arm/ui/TabConsole.hx
@@ -20,7 +20,7 @@ class TabConsole {
 		if (ui.tab(UIStatus.inst.statustab, title, false, color) && statush > UIStatus.defaultStatusH * ui.SCALE()) {
 
 			ui.beginSticky();
-			ui.row([1 / 14, 1 / 14]);
+			ui.row([1 / 14, 1 / 14 #if !(kha_android || kha_ios) , 1 / 14 #end]);
 
 			if (ui.button(tr("Clear"))) {
 				Console.lastTraces = [];
@@ -35,6 +35,12 @@ class TabConsole {
 					Krom.fileSaveBytes(path, Bytes.ofString(str).getData());
 				});
 			}
+			#if !(kha_android || kha_ios)
+			if (ui.button(tr("Copy"))) {
+				var str = Console.lastTraces.join("\n");
+				Krom.copyToClipboard(str);
+			}
+			#end
 
 			ui.endSticky();
 

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -108,12 +108,19 @@ class TabSwatches {
 								Context.setSwatch(Project.makeSwatch(Context.swatch.base));
 								Project.raw.swatches.push(Context.swatch);
 							}
+							#if !(kha_android || kha_ios)
+							else if (ui.button(tr("Copy Hex code"), Left)) {
+								var val = untyped Context.swatch.base;
+								if (val < 0) val += untyped 4294967296;
+								Krom.copyToClipboard(untyped val.toString(16));
+							}
+							#end
 							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left)) {
 								Context.setSwatch(Project.raw.swatches[i == 0 ? 1 : 0]);
 								Project.raw.swatches.splice(i, 1);
 								UIStatus.inst.statusHandle.redraws = 2;
 							}
-						}, 2 + add);
+						}, #if !(kha_android || kha_ios) 3 + add #else 2 + add #end);
 					}
 					if (ui.isHovered) {
 						var val = untyped Project.raw.swatches[i].base;

--- a/Sources/arm/ui/UIBox.hx
+++ b/Sources/arm/ui/UIBox.hx
@@ -67,8 +67,20 @@ class UIBox {
 						Ext.textArea(ui, Id.handle({text: boxText}), false) :
 						ui.text(boxText);
 					ui.endElement();
+					#if !(kha_android || kha_ios)
+					if(copyable) ui.row([1 / 3, 1 / 3, 1 / 3]);
+					else ui.row([2 / 3, 1 / 3]);
+					#else
 					ui.row([2 / 3, 1 / 3]);
+					#end
+
+
 					ui.endElement();
+					#if !(kha_android || kha_ios)
+					if (copyable && ui.button(tr("Copy"))) {
+						Krom.copyToClipboard(boxText);
+					}
+					#end
 					if (ui.button(tr("OK"))) {
 						show = false;
 						App.redrawUI();


### PR DESCRIPTION
As discussed I implemented a copy feature at some useful places.
1. Swatches got an copy hex color feature to transfer hex colors to other applications/inside of ArmorPaint.
2. The console text can be copied now. This is useful copy and paste error messages without having to export them.
3. Copyable UIBoxes have a copy button now. This was mainly done for the About dialog.
Notice that the features are only available on Windows, Linux and Mac due to limitations of kinc. (I think Ctrl+C,V,X is also not available on Android and iOS, so this should be no limitation). I hope I chose the correct condition as I could not find a kha_windows | kha_linux | kha_mac condition.