### PR TITLE
Drag for swatch in materials and layers

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -1,5 +1,6 @@
 package arm;
 
+import arm.ui.TabMaterials;
 import haxe.io.Bytes;
 import kha.graphics2.truetype.StbTruetype;
 import kha.Image;
@@ -376,6 +377,8 @@ class App {
 							 Context.paintVec.y < 1 && Context.paintVec.y > 0;
 			var inLayers = UISidebar.inst.htab0.position == 0 &&
 						   mx > UISidebar.inst.tabx && my < Config.raw.layout[LayoutSidebarH0];
+			var inMaterials = UISidebar.inst.htab1.position == 0 &&
+						   mx > UISidebar.inst.tabx && my > Config.raw.layout[LayoutSidebarH0] && my < Config.raw.layout[LayoutSidebarH1] + Config.raw.layout[LayoutSidebarH0];
 			var in2dView = UIView2D.inst.show && UIView2D.inst.type == View2DLayer &&
 						   mx > UIView2D.inst.wx && mx < UIView2D.inst.wx + UIView2D.inst.ww &&
 						   my > UIView2D.inst.wy && my < UIView2D.inst.wy + UIView2D.inst.wh;
@@ -400,6 +403,12 @@ class App {
 			else if (dragSwatch != null) {
 				if (inNodes) { // Create RGB node
 					UINodes.inst.acceptSwatchDrag(Project.raw.swatches.indexOf(dragSwatch));
+				}
+				else if (inMaterials) {
+					TabMaterials.acceptSwatchDrag(Project.raw.swatches.indexOf(dragSwatch));
+				}
+				else if (inLayers || inViewport) {
+					Layers.createColorLayer(dragSwatch.base.value);
 				}
 				dragSwatch = null;
 			}
@@ -469,7 +478,7 @@ class App {
 			UINodes.inst.acceptMaterialDrag(Project.materials.indexOf(dragMaterial));
 		}
 		dragMaterial = null;
-	}
+	} 
 
 	static function handleDropPaths() {
 		if (dropPaths.length > 0) {

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -916,4 +916,16 @@ class Layers {
 		m.clear(0x00000000, Project.getImage(asset));
 		Context.layerPreviewDirty = true;
 	}
+
+	public static function createColorLayer(baseColor: Int) {
+		function _init() {
+			var l = newLayer(false);
+			History.newLayer();
+			l.uvType = UVMap;
+			l.objectMask = Context.layerFilter;
+			l.clear(baseColor);
+		}
+		iron.App.notifyOnInit(_init);
+	}
+
 }

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -228,4 +228,17 @@ class TabMaterials {
 			}
 		}
 	}
+
+	public static function acceptSwatchDrag(index: Int) {
+		Context.material = new MaterialSlot(Project.materials[0].data);
+		for (node in Context.material.canvas.nodes) {
+			if (node.type == "RGB" ) {
+				var color = Project.raw.swatches[index].base;
+				node.outputs[0].default_value = [color.R, color.G, color.B, color.A];
+			}
+		}
+		Project.materials.push(Context.material);
+		updateMaterial();
+		History.newMaterial();
+	}
 }


### PR DESCRIPTION
Currently creating a solid material to paint with from a swatch requires the user to create a new material, drag and drop the swatch in the node editor and rewire everything. It is way quicker to simply drag and drop a swatch in the material tab to create this material.
Similarly filling an object or parts of it with a swatch requires the user to create a material as described above and then to fill a paint layer/create a fill layer. It is way more convenient to simply drag and drop a swatch in the layers tab or the viewport.

Maybe this partly implements #1174.