### PR TITLE
Improve swatches

### DIFF
--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -495,9 +495,9 @@ class Project {
 		});
 	}
 
-	public static function importSwatches() {
+	public static function importSwatches(replaceExisting = false) {
 		UIFiles.show("arm", false, false, function(path: String) {
-			ImportArm.runSwatches(path);
+			ImportArm.runSwatches(path, replaceExisting);
 		});
 	}
 

--- a/Sources/arm/io/ImportArm.hx
+++ b/Sources/arm/io/ImportArm.hx
@@ -502,17 +502,27 @@ class ImportArm {
 		Data.deleteBlob(path);
 	}
 
-	public static function runSwatches(path: String) {
+	public static function runSwatches(path: String, replaceExisting = false) {
 		Data.getBlob(path, function(b: Blob) {
 			var project: TProjectFormat = ArmPack.decode(b.toBytes());
 			if (project.version == null) { Data.deleteBlob(path); return; }
-			runSwatchesFromProject(project, path);
+			runSwatchesFromProject(project, path, replaceExisting);
 		});
 	}
 
-	public static function runSwatchesFromProject(project: TProjectFormat, path: String) {
-		for (s in project.swatches) {
-			Project.raw.swatches.push(s);
+	public static function runSwatchesFromProject(project: TProjectFormat, path: String, replaceExisting = false) {
+		if (replaceExisting) {
+			Project.raw.swatches = [];
+
+			if (project.swatches == null) { //no swatches contained
+				Project.raw.swatches.push(Project.makeSwatch());
+			}
+		}
+
+		if (project.swatches != null) {
+			for (s in project.swatches) {
+				Project.raw.swatches.push(s);
+			}
 		}
 		UIStatus.inst.statusHandle.redraws = 2;
 		Data.deleteBlob(path);

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -19,18 +19,33 @@ class TabSwatches {
 
 			ui.beginSticky();
 			#if arm_touchui
-			ui.row([1 / 4, 1 / 4, 1 / 4, 1 / 4]);
+			ui.row([1 / 5, 1 / 5, 1 / 5, 1 / 5, 1 / 5]);
 			#else
-			ui.row([1 / 14, 1 / 14, 1 / 14, 1 / 14]);
+			ui.row([1 / 14, 1 / 14, 1 / 14, 1 / 14, 1 / 14]);
 			#end
 
 			if (ui.button(tr("New"))) {
 				Context.setSwatch(Project.makeSwatch());
 				Project.raw.swatches.push(Context.swatch);
 			}
+			if (ui.isHovered) ui.tooltip(tr("Add new swatch"));
 
-			if (ui.button(tr("Import"))) Project.importSwatches();
+			if (ui.button(tr("Import"))) {
+				UIMenu.draw(function(ui: Zui) {
+					ui.text(tr("Import"), Right, ui.t.HIGHLIGHT_COL);
+					if (ui.button(tr("Replace Existing"), Left)) {
+						Project.importSwatches(true);
+						Context.setSwatch(Project.raw.swatches[0]);
+					}
+					if (ui.button(tr("Append"), Left)) {
+						Project.importSwatches(false);
+					}
+				}, 3);
+			}	
 			if (ui.isHovered) ui.tooltip(tr("Import swatches"));
+
+			if (ui.button(tr("Export"))) Project.exportSwatches();
+			if (ui.isHovered) ui.tooltip(tr("Export swatches"));
 
 			if (ui.button(tr("Clear"))) {
 				Context.setSwatch(Project.makeSwatch());
@@ -41,6 +56,7 @@ class TabSwatches {
 				Project.setDefaultSwatches();
 				Context.setSwatch(Project.raw.swatches[0]);
 			}
+			if (ui.isHovered) ui.tooltip(tr("Restore default swatches"));
 
 			ui.endSticky();
 			ui.separator(3, false);


### PR DESCRIPTION
I improved the swatch handling in various ways

1. Fixed the bug when importing a arm file as swatch file but it actually does not contain any.
2. Added an export button based on @AlexKiryanov's idea https://github.com/armory3d/armorpaint/issues/1106#issuecomment-907467661
3. Added the option to replace or add swatches on import. Previously it was only possible to add them but not to replace them.
4. Added some tooltips to make the  swatches tab more intuitive.