### PR TITLE
Export shared layers to all atlases

### DIFF
--- a/Sources/arm/io/ExportTexture.hx
+++ b/Sources/arm/io/ExportTexture.hx
@@ -73,7 +73,7 @@ class ExportTexture {
 					for (objectIndex in 0...Project.atlasObjects.length) {
 						if (Project.atlasObjects[objectIndex] == atlasIndex) {
 							for (l in Project.layers) {
-								if (l.getObjectMask() - 1 == objectIndex) layers.push(l);
+								if (l.getObjectMask() == 0 /* shared object */ || l.getObjectMask() - 1 == objectIndex) layers.push(l);
 							}
 						}
 					}


### PR DESCRIPTION
This fixes #1254. 
Currently it is not possible to export "shared" layers in a atlas setup. Imho the user would expect that these layers are exported to all atlases because they are shown in the layer view if a certain object is chosen, too.