### PR TITLE
Colorwheel preview

### DIFF
--- a/Sources/arm/ui/BoxPreferences.hx
+++ b/Sources/arm/ui/BoxPreferences.hx
@@ -195,9 +195,9 @@ class BoxPreferences {
 				if (ui.isHovered && ui.inputReleased) {
 					UIMenu.draw(function(ui) {
 						ui.changed = false;
-						zui.Ext.colorWheel(ui, h, false, null, false);
+						zui.Ext.colorWheel(ui, h, false, null, true);
 						if (ui.changed) UIMenu.keepOpen = true;
-					}, 10);
+					}, 11);
 				}
 				var val = untyped h.color;
 				if (val < 0) val += untyped 4294967296;

--- a/Sources/arm/ui/BoxPreferences.hx
+++ b/Sources/arm/ui/BoxPreferences.hx
@@ -235,9 +235,9 @@ class BoxPreferences {
 							h.color = untyped theme[key];
 							UIMenu.draw(function(ui) {
 								ui.changed = false;
-								untyped theme[key] = zui.Ext.colorWheel(ui, h, false, null, false);
+								untyped theme[key] = zui.Ext.colorWheel(ui, h, false, null, true);
 								if (ui.changed) UIMenu.keepOpen = true;
-							}, 10);
+							}, 11);
 						}
 					}
 

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -111,10 +111,10 @@ class TabSwatches {
 								ui.changed = false;
 								var h = Id.handle();
 								h.color = Context.swatch.base;
-								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, false);
+								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, true);
 								if (ui.changed || ui.isTyping) UIMenu.keepOpen = true;
 								if (ui.inputReleased) Context.setSwatch(Context.swatch); // Trigger material preview update
-							}, 10, Std.int(Input.getMouse().x - 200 * ui.SCALE()), Std.int(Input.getMouse().y - 250 * ui.SCALE()));
+							}, 11, Std.int(Input.getMouse().x - 200 * ui.SCALE()), Std.int(Input.getMouse().y - 250 * ui.SCALE()));
 						}
 
 						Context.selectTime = Time.time();


### PR DESCRIPTION
The previews for the color wheel are very handy. This PR enhances selecting a new swatch color by enabling the preview and does the same in the theming section in the preferences dialog.
Fixes parts of https://github.com/armory3d/armorpaint/issues/1106
