### PR TITLE
Open Texture in Browser

### DIFF
--- a/Sources/arm/ui/TabBrowser.hx
+++ b/Sources/arm/ui/TabBrowser.hx
@@ -13,6 +13,12 @@ class TabBrowser {
 	static var known = false;
 	static var lastPath =  "";
 
+	public static function showDirectory(directory : String) {
+		hpath.text = directory;
+		hsearch.text = "";
+		UIStatus.inst.statustab.position = 0;
+	}
+
 	@:access(zui.Zui)
 	public static function draw() {
 		var ui = UISidebar.inst.ui;

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -138,7 +138,10 @@ class TabTextures {
 								if (!isPacked && ui.button(tr("Open Containing Directory..."), Left)) {
 									File.start(asset.file.substr(0, asset.file.lastIndexOf(Path.sep)));
 								}
-							}, isPacked ? 5 : 6);
+								if (!isPacked && ui.button(tr("Open in Browser"), Left)) {
+									TabBrowser.showDirectory(asset.file.substr(0, asset.file.lastIndexOf(Path.sep)));
+								}
+							}, isPacked ? 5 : 7);
 						}
 
 						if (Config.raw.show_asset_names) {


### PR DESCRIPTION
The ArmorPaint Browser is much more usable than it was some time ago. ArmorPaint also supports to open the containing folder of a texture in the OS's native file explorer. This PR adds a feature to open it in the ArmorPaint browser as well.