### PR TITLE
Improve picker

### DIFF
--- a/Sources/arm/Context.hx
+++ b/Sources/arm/Context.hx
@@ -64,6 +64,7 @@ class Context {
 	public static var savedCamera = Mat4.identity();
 
 	public static var swatch: TSwatchColor;
+	public static var pickedColor: TSwatchColor = Project.makeSwatch();
 	public static var materialIdPicked = 0;
 	public static var uvxPicked = 0.0;
 	public static var uvyPicked = 0.0;

--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -270,7 +270,7 @@ class Project {
 			Context.font = fonts[0];
 			Project.setDefaultSwatches();
 			Context.swatch = Project.raw.swatches[0];
-
+			Context.pickedColor = Project.makeSwatch();
 			History.reset();
 
 			MakeMaterial.parsePaintMaterial();

--- a/Sources/arm/render/RenderPathPaint.hx
+++ b/Sources/arm/render/RenderPathPaint.hx
@@ -208,31 +208,31 @@ class RenderPathPaint {
 
 					// Picked surface values
 					#if (kha_metal || kha_vulkan)
-					Context.swatch.base.Rb = a.get(2);
-					Context.swatch.base.Gb = a.get(1);
-					Context.swatch.base.Bb = a.get(0);
-					Context.swatch.normal.Rb = b.get(2);
-					Context.swatch.normal.Gb = b.get(1);
-					Context.swatch.normal.Bb = b.get(0);
-					Context.swatch.occlusion = c.get(2) / 255;
-					Context.swatch.roughness = c.get(1) / 255;
-					Context.swatch.metallic = c.get(0) / 255;
-					Context.swatch.height = c.get(3) / 255;
-					Context.swatch.opacity = a.get(3) / 255;
+					Context.pickedColor.base.Rb = a.get(2);
+					Context.pickedColor.base.Gb = a.get(1);
+					Context.pickedColor.base.Bb = a.get(0);
+					Context.pickedColor.normal.Rb = b.get(2);
+					Context.pickedColor.normal.Gb = b.get(1);
+					Context.pickedColor.normal.Bb = b.get(0);
+					Context.pickedColor.occlusion = c.get(2) / 255;
+					Context.pickedColor.roughness = c.get(1) / 255;
+					Context.pickedColor.metallic = c.get(0) / 255;
+					Context.pickedColor.height = c.get(3) / 255;
+					Context.pickedColor.opacity = a.get(3) / 255;
 					Context.uvxPicked = d.get(2) / 255;
 					Context.uvyPicked = d.get(1) / 255;
 					#else
-					Context.swatch.base.Rb = a.get(0);
-					Context.swatch.base.Gb = a.get(1);
-					Context.swatch.base.Bb = a.get(2);
-					Context.swatch.normal.Rb = b.get(0);
-					Context.swatch.normal.Gb = b.get(1);
-					Context.swatch.normal.Bb = b.get(2);
-					Context.swatch.occlusion = c.get(0) / 255;
-					Context.swatch.roughness = c.get(1) / 255;
-					Context.swatch.metallic = c.get(2) / 255;
-					Context.swatch.height = c.get(3) / 255;
-					Context.swatch.opacity = a.get(3) / 255;
+					Context.pickedColor.base.Rb = a.get(0);
+					Context.pickedColor.base.Gb = a.get(1);
+					Context.pickedColor.base.Bb = a.get(2);
+					Context.pickedColor.normal.Rb = b.get(0);
+					Context.pickedColor.normal.Gb = b.get(1);
+					Context.pickedColor.normal.Bb = b.get(2);
+					Context.pickedColor.occlusion = c.get(0) / 255;
+					Context.pickedColor.roughness = c.get(1) / 255;
+					Context.pickedColor.metallic = c.get(2) / 255;
+					Context.pickedColor.height = c.get(3) / 255;
+					Context.pickedColor.opacity = a.get(3) / 255;
 					Context.uvxPicked = d.get(0) / 255;
 					Context.uvyPicked = d.get(1) / 255;
 					#end

--- a/Sources/arm/render/Uniforms.hx
+++ b/Sources/arm/render/Uniforms.hx
@@ -106,19 +106,19 @@ class Uniforms {
 				return Context.layer.decalMat.getScale().z * 0.5;
 			}
 			case "_pickerOpacity": {
-				return Context.swatch.opacity;
+				return Context.pickedColor.opacity;
 			}
 			case "_pickerOcclusion": {
-				return Context.swatch.occlusion;
+				return Context.pickedColor.occlusion;
 			}
 			case "_pickerRoughness": {
-				return Context.swatch.roughness;
+				return Context.pickedColor.roughness;
 			}
 			case "_pickerMetallic": {
-				return Context.swatch.metallic;
+				return Context.pickedColor.metallic;
 			}
 			case "_pickerHeight": {
-				return Context.swatch.height;
+				return Context.pickedColor.height;
 			}
 		}
 		if (MaterialParser.script_links != null) {
@@ -206,12 +206,12 @@ class Uniforms {
 			}
 			case "_pickerBase": {
 				v = iron.object.Uniforms.helpVec;
-				v.set(Context.swatch.base.R, Context.swatch.base.G, Context.swatch.base.B);
+				v.set(Context.pickedColor.base.R, Context.pickedColor.base.G, Context.pickedColor.base.B);
 				return v;
 			}
 			case "_pickerNormal": {
 				v = iron.object.Uniforms.helpVec;
-				v.set(Context.swatch.normal.R, Context.swatch.normal.G, Context.swatch.normal.B);
+				v.set(Context.pickedColor.normal.R, Context.pickedColor.normal.G, Context.pickedColor.normal.B);
 				return v;
 			}
 		}

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -69,6 +69,13 @@ class UIHeader {
 						if (ui.changed) UIMenu.keepOpen = true;
 					}, 10);
 				}
+				if (ui.button("Add swatch")) {
+					var newSwatch = Project.makeSwatch(Context.pickedColor.base);
+					Context.setSwatch(newSwatch);
+					Project.raw.swatches.push(newSwatch);
+					UIStatus.inst.statusHandle.redraws = 1;
+				}
+				if (ui.isHovered) ui.tooltip(tr("Add picker color to swatches"));
 
 				ui.text(tr("Base") + ' ($baseRPicked,$baseGPicked,$baseBPicked)');
 				ui.text(tr("Normal") + ' ($normalRPicked,$normalGPicked,$normalBPicked)');

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -44,17 +44,17 @@ class UIHeader {
 				if (Project.assets.length > 0) ui.image(Project.getImage(Project.assets[cid]));
 			}
 			else if (Context.tool == ToolPicker) {
-				var baseRPicked = Math.round(Context.swatch.base.R * 10) / 10;
-				var baseGPicked = Math.round(Context.swatch.base.G * 10) / 10;
-				var baseBPicked = Math.round(Context.swatch.base.B * 10) / 10;
-				var normalRPicked = Math.round(Context.swatch.normal.R * 10) / 10;
-				var normalGPicked = Math.round(Context.swatch.normal.G * 10) / 10;
-				var normalBPicked = Math.round(Context.swatch.normal.B * 10) / 10;
-				var occlusionPicked = Math.round(Context.swatch.occlusion * 100) / 100;
-				var roughnessPicked = Math.round(Context.swatch.roughness * 100) / 100;
-				var metallicPicked = Math.round(Context.swatch.metallic * 100) / 100;
-				var heightPicked = Math.round(Context.swatch.height * 100) / 100;
-				var opacityPicked = Math.round(Context.swatch.opacity * 100) / 100;
+				var baseRPicked = Math.round(Context.pickedColor.base.R * 10) / 10;
+				var baseGPicked = Math.round(Context.pickedColor.base.G * 10) / 10;
+				var baseBPicked = Math.round(Context.pickedColor.base.B * 10) / 10;
+				var normalRPicked = Math.round(Context.pickedColor.normal.R * 10) / 10;
+				var normalGPicked = Math.round(Context.pickedColor.normal.G * 10) / 10;
+				var normalBPicked = Math.round(Context.pickedColor.normal.B * 10) / 10;
+				var occlusionPicked = Math.round(Context.pickedColor.occlusion * 100) / 100;
+				var roughnessPicked = Math.round(Context.pickedColor.roughness * 100) / 100;
+				var metallicPicked = Math.round(Context.pickedColor.metallic * 100) / 100;
+				var heightPicked = Math.round(Context.pickedColor.height * 100) / 100;
+				var opacityPicked = Math.round(Context.pickedColor.opacity * 100) / 100;
 
 				var h = Id.handle();
 				h.color.R = baseRPicked;


### PR DESCRIPTION
This PR seperates the color picker and the swatches (`Context.swatch`). This avoids the annoying behavior of contantly destroying the swatches palette by the color picker. I also added a button to add the newly picked color as a new swatch. Maybe it would be a good idea to have a swatches icon in the future to make the button smaller.
Fixes #892
Fixes #1108
Fixes #1137