### PR TITLE
Add shortcuts to tooltips

### DIFF
--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -313,7 +313,8 @@ class TabLayers {
 			else {
 				ui.tooltipImage(l.texpaint_preview);
 			}
-			ui.tooltip(l.name);
+			if(i < 9) ui.tooltip(l.name + " - (" + Config.keymap.select_layer + " " + (i+1) + ")");
+			else ui.tooltip(l.name);
 		}
 		if (ui.isHovered && ui.inputReleasedR) {
 			Context.setLayer(l);

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -176,14 +176,16 @@ class TabMaterials {
 					}
 					if (ui.isHovered) {
 						ui.tooltipImage(imgFull);
-						ui.tooltip(Project.materials[i].canvas.name);
+						if (i < 9 && ui.isHovered) ui.tooltip(Project.materials[i].canvas.name + " - (" + Config.keymap.select_material + " " + (i+1) + ")");
+						else ui.tooltip(Project.materials[i].canvas.name);
 					}
 
 					if (Config.raw.show_asset_names) {
 						ui._x = uix;
 						ui._y += slotw * 0.9;
 						ui.text(Project.materials[i].canvas.name, Center);
-						if (ui.isHovered) ui.tooltip(Project.materials[i].canvas.name);
+						if (i < 9 && ui.isHovered) ui.tooltip(Project.materials[i].canvas.name + " - (" + Config.keymap.select_material + " " + (i+1) + ")");
+						else ui.tooltip(Project.materials[i].canvas.name);
 						ui._y -= slotw * 0.9;
 						if (i == Project.materials.length - 1) {
 							ui._y += j == num - 1 ? imgw : imgw + ui.ELEMENT_H() + ui.ELEMENT_OFFSET();

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -176,7 +176,7 @@ class TabMaterials {
 					}
 					if (ui.isHovered) {
 						ui.tooltipImage(imgFull);
-						if (i < 9 && ui.isHovered) ui.tooltip(Project.materials[i].canvas.name + " - (" + Config.keymap.select_material + " " + (i+1) + ")");
+						if (i < 9) ui.tooltip(Project.materials[i].canvas.name + " - (" + Config.keymap.select_material + " " + (i+1) + ")");
 						else ui.tooltip(Project.materials[i].canvas.name);
 					}
 
@@ -184,8 +184,10 @@ class TabMaterials {
 						ui._x = uix;
 						ui._y += slotw * 0.9;
 						ui.text(Project.materials[i].canvas.name, Center);
-						if (i < 9 && ui.isHovered) ui.tooltip(Project.materials[i].canvas.name + " - (" + Config.keymap.select_material + " " + (i+1) + ")");
-						else ui.tooltip(Project.materials[i].canvas.name);
+						if (ui.isHovered) {
+							if (i < 9) ui.tooltip(Project.materials[i].canvas.name + " - (" + Config.keymap.select_material + " " + (i+1) + ")");
+							else ui.tooltip(Project.materials[i].canvas.name);
+						}
 						ui._y -= slotw * 0.9;
 						if (i == Project.materials.length - 1) {
 							ui._y += j == num - 1 ? imgw : imgw + ui.ELEMENT_H() + ui.ELEMENT_OFFSET();

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -191,9 +191,11 @@ class UIHeader {
 				if (Context.tool != ToolFill) {
 					if (decalMask) {
 						Context.brushDecalMaskRadius = ui.slider(Context.brushDecalMaskRadiusHandle, tr("Radius"), 0.01, 2.0, true);
+						if (ui.isHovered) ui.tooltip(tr("Hold {brush_radius} and move mouse to the left or press {brush_radius_decrease} to decrease the radius\nHold {brush_radius} and move mouse to the right or press {brush_radius_increase} to increase the radius", ["brush_radius" => Config.keymap.brush_radius, "brush_radius_decrease" => Config.keymap.brush_radius_decrease, "brush_radius_increase" => Config.keymap.brush_radius_increase]));
 					}
 					else {
 						Context.brushRadius = ui.slider(Context.brushRadiusHandle, tr("Radius"), 0.01, 2.0, true);
+						if (ui.isHovered) ui.tooltip(tr("Hold {brush_radius} and move mouse to the left or press {brush_radius_decrease} to decrease the radius\nHold {brush_radius} and move mouse to the right or press {brush_radius_increase} to increase the radius", ["brush_radius" => Config.keymap.brush_radius, "brush_radius_decrease" => Config.keymap.brush_radius_decrease, "brush_radius_increase" => Config.keymap.brush_radius_increase]));	
 					}
 				}
 
@@ -216,12 +218,15 @@ class UIHeader {
 					}
 
 					Context.brushAngle = ui.slider(Context.brushAngleHandle, tr("Angle"), 0.0, 360.0, true, 1);
+					if (ui.isHovered) ui.tooltip(tr("Hold {brush_angle} and move mouse to the right to decrease the angle\nHold {brush_angle} and move mouse to the left to increase the angle", ["brush_angle" => Config.keymap.brush_angle]));
+
 					if (Context.brushAngleHandle.changed) {
 						MakeMaterial.parsePaintMaterial();
 					}
 				}
 
 				Context.brushOpacity = ui.slider(Context.brushOpacityHandle, tr("Opacity"), 0.0, 1.0, true);
+				if (ui.isHovered) ui.tooltip(tr("Hold {brush_opacity} and move mouse to the left to decrease the opacity\nHold {brush_opacity} and move mouse to the right to increase the opacity", ["brush_opacity" => Config.keymap.brush_opacity]));
 
 				if (Context.tool == ToolBrush || Context.tool == ToolEraser || decalMask) {
 					Context.brushHardness = ui.slider(Id.handle({value: Context.brushHardness}), tr("Hardness"), 0.0, 1.0, true);

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -218,7 +218,7 @@ class UIHeader {
 					}
 
 					Context.brushAngle = ui.slider(Context.brushAngleHandle, tr("Angle"), 0.0, 360.0, true, 1);
-					if (ui.isHovered) ui.tooltip(tr("Hold {brush_angle} and move mouse to the right to decrease the angle\nHold {brush_angle} and move mouse to the left to increase the angle", ["brush_angle" => Config.keymap.brush_angle]));
+					if (ui.isHovered) ui.tooltip(tr("Hold {brush_angle} and move mouse to the left to decrease the angle\nHold {brush_angle} and move mouse to the right to increase the angle", ["brush_angle" => Config.keymap.brush_angle]));
 
 					if (Context.brushAngleHandle.changed) {
 						MakeMaterial.parsePaintMaterial();

--- a/Sources/arm/ui/UISidebar.hx
+++ b/Sources/arm/ui/UISidebar.hx
@@ -227,7 +227,7 @@ class UISidebar {
 						Context.brushOpacityHandle.value = Context.brushOpacity;
 					}
 					else if (Operator.shortcut(Config.keymap.brush_angle, ShortcutDown)) {
-						Context.brushAngle -= mouse.movementX / 5;
+						Context.brushAngle += mouse.movementX / 5;
 						Context.brushAngle = Std.int(Context.brushAngle) % 360;
 						if (Context.brushAngle < 0) Context.brushAngle += 360;
 						Context.brushAngleHandle.value = Context.brushAngle;

--- a/Sources/arm/ui/UIToolbar.hx
+++ b/Sources/arm/ui/UIToolbar.hx
@@ -55,11 +55,11 @@ class UIToolbar {
 
 			if (UIHeader.inst.worktab.position == SpacePaint) {
 				var keys = [
-					"(" + Config.keymap.tool_brush + ")",
-					"(" + Config.keymap.tool_eraser + ")",
+					"(" + Config.keymap.tool_brush + ") - "+ tr("Hold {action_paint} to paint\nHold {key} and press {action_paint} to paint a straight line (ruler mode)", ["key" => Config.keymap.brush_ruler, "action_paint" => Config.keymap.action_paint]),
+					"(" + Config.keymap.tool_eraser + ") - "+ tr("Hold {action_paint} to erase\nHold {key} and press {action_paint} to erase a straight line (ruler mode)", ["key" => Config.keymap.brush_ruler, "action_paint" => Config.keymap.action_paint]),
 					"(" + Config.keymap.tool_fill + ")",
-					"(" + Config.keymap.tool_decal + ")",
-					"(" + Config.keymap.tool_text + ")",
+					"(" + Config.keymap.tool_decal + ") - "+ tr("Hold {key} to paint on a decal mask", ["key" => Config.keymap.decal_mask]),
+					"(" + Config.keymap.tool_text + ") - "+ tr("Hold {key} to use the text as a mask", ["key" => Config.keymap.decal_mask]),
 					"(" + Config.keymap.tool_clone + ") - " + tr("Hold {key} to set source", ["key" => Config.keymap.set_clone_source]),
 					"(" + Config.keymap.tool_blur + ")",
 					"(" + Config.keymap.tool_particle + ")",


### PR DESCRIPTION
Implements #928.
I think it helps the user a lot to hover controls and see their shortcuts and related shortcuts to more advanced functions like ruler mode or painting on a decal mask. 
You might want to change my wording a bit in case you do not like it.