### PR TITLE
Separate camera pan, rotation and zoom speed

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -745,7 +745,9 @@ class App {
 		raw.brush_depth_reject = true;
 		raw.brush_angle_reject = true;
 		raw.brush_live = false;
-		raw.camera_speed = 1.0;
+		raw.camera_zoom_speed = 1.0;
+		raw.camera_pan_speed = 1.0;
+		raw.camera_rotation_speed = 1.0;
 		raw.zoom_direction = ZoomVertical;
 		raw.displace_strength = 0.0;
 		raw.show_asset_names = false;

--- a/Sources/arm/ConfigFormat.hx
+++ b/Sources/arm/ConfigFormat.hx
@@ -45,7 +45,9 @@ typedef TConfig = {
 	@:optional var brush_angle_reject: Null<Bool>;
 	@:optional var wrap_mouse: Null<Bool>;
 	@:optional var node_preview: Null<Bool>;
-	@:optional var camera_speed: Null<Float>;
+	@:optional var camera_pan_speed: Null<Float>;
+	@:optional var camera_zoom_speed: Null<Float>;
+	@:optional var camera_rotation_speed: Null<Float>;
 	@:optional var zoom_direction: Null<Int>;
 	@:optional var displace_strength: Null<Float>;
 	@:optional var show_asset_names: Null<Bool>;

--- a/Sources/arm/ui/BoxPreferences.hx
+++ b/Sources/arm/ui/BoxPreferences.hx
@@ -58,8 +58,14 @@ class BoxPreferences {
 				}
 				Context.hscaleWasChanged = hscale.changed;
 
-				var hspeed = Id.handle({ value: Config.raw.camera_speed });
-				Config.raw.camera_speed = ui.slider(hspeed, tr("Camera Speed"), 0.1, 4.0, true);
+				var hspeed = Id.handle({value: Config.raw.camera_zoom_speed});
+				Config.raw.camera_zoom_speed = ui.slider(hspeed, tr("Camera Zoom Speed"), 0.1, 4.0, true);
+
+				hspeed = Id.handle({value: Config.raw.camera_rotation_speed});
+				Config.raw.camera_rotation_speed = ui.slider(hspeed, tr("Camera Rotation Speed"), 0.1, 4.0, true);
+
+				hspeed = Id.handle({value: Config.raw.camera_pan_speed});
+				Config.raw.camera_pan_speed = ui.slider(hspeed, tr("Camera Pan Speed"), 0.1, 4.0, true);
 
 				var zoomDirectionHandle = Id.handle({ position: Config.raw.zoom_direction });
 				ui.combo(zoomDirectionHandle, [tr("Vertical"), tr("Vertical Inverted"), tr("Horizontal"), tr("Horizontal Inverted"), tr("Vertical and Horizontal"), tr("Vertical and Horizontal Inverted")], tr("Direction to Zoom"), true);


### PR DESCRIPTION
Tried to implement #1292.
I split the camera speed in three speeds for pan, zoom and rotate as requested. I also had to adjust armorbase, see #15. There I implemented an upgrade path for older configurations, i.e. existing ArmorPaint users who rebuild their ArmorPaint after a git pull. Otherwise the users would have the problem that the camera moves weirdly because the speeds are null. The upgrade path can be removed eventually.