### PR TITLE
Create no empty materials on drag and drop.

### DIFF
--- a/Sources/arm/io/ImportFolder.hx
+++ b/Sources/arm/io/ImportFolder.hx
@@ -25,6 +25,7 @@ class ImportFolder {
 		var mapmet = "";
 		var mapheight = "";
 
+		var foundTexture = false;
 		// Import maps
 		for (f in files) {
 			if (!Path.isTexture(f)) continue;
@@ -62,7 +63,15 @@ class ImportFolder {
 				valid = true;
 			}
 
-			if (valid) ImportTexture.run(path + Path.sep + f);
+			if (valid) {
+				ImportTexture.run(path + Path.sep + f);
+				foundTexture = true;
+			}
+		}
+
+		if (!foundTexture) {
+			Console.info(tr("Folder does not contain textures"));
+			return;
 		}
 
 		// Create material


### PR DESCRIPTION
As described in #1294 I think the behavior of creating empty materials is a bit unfortunate because it is almost certainly not what a user intended to do. Either the user dropped the wrong folder or a folder containing texture files in a format ArmorPaint can not load. Thus I skipped creating a new material and print a warning instead.

Question: Are you sure you want to create an env-map in ImportFolder? I think 
`ImportTexture.run(path + Path.sep + f, false);` would be better, wouldn't it?