### PR TITLE
Swatch improvements

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -409,10 +409,10 @@ class App {
 			}
 			else if (dragSwatch != null) {
 				if (inNodes) { // Create RGB node
-					UINodes.inst.acceptSwatchDrag(Project.raw.swatches.indexOf(dragSwatch));
+					UINodes.inst.acceptSwatchDrag(dragSwatch);
 				}
 				else if (inMaterials) {
-					TabMaterials.acceptSwatchDrag(Project.raw.swatches.indexOf(dragSwatch));
+					TabMaterials.acceptSwatchDrag(dragSwatch);
 				}
 				else if (inLayers || inViewport) {
 					Layers.createColorLayer(dragSwatch.base.value);

--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -388,6 +388,10 @@ class App {
 			var inNodes = UINodes.inst.show &&
 						  mx > UINodes.inst.wx && mx < UINodes.inst.wx + UINodes.inst.ww &&
 						  my > UINodes.inst.wy && my < UINodes.inst.wy + UINodes.inst.wh;
+			var inSwatches = UIStatus.inst.statustab.position == 4 && 
+						  mx > iron.App.x() && mx < iron.App.x() + System.windowWidth() - UIToolbar.inst.toolbarw - Config.raw.layout[LayoutSidebarW] &&
+						  my > System.windowHeight() - Config.raw.layout[LayoutStatusH];
+
 			if (dragAsset != null) {
 				if (inNodes) { // Create image texture
 					UINodes.inst.acceptAssetDrag(Project.assets.indexOf(dragAsset));
@@ -412,6 +416,9 @@ class App {
 				}
 				else if (inLayers || inViewport) {
 					Layers.createColorLayer(dragSwatch.base.value);
+				}
+				else if (inSwatches) {
+					TabSwatches.acceptSwatchDrag(dragSwatch);
 				}
 				dragSwatch = null;
 			}

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -10,6 +10,7 @@ import iron.object.MeshObject;
 import iron.data.Data;
 import arm.node.MakeMaterial;
 import arm.data.MaterialSlot;
+import arm.ProjectFormat.TSwatchColor;
 import arm.util.RenderUtil;
 import arm.sys.Path;
 import arm.Enums;
@@ -234,12 +235,11 @@ class TabMaterials {
 		}
 	}
 
-	public static function acceptSwatchDrag(index: Int) {
+	public static function acceptSwatchDrag(swatch: TSwatchColor) {
 		Context.material = new MaterialSlot(Project.materials[0].data);
 		for (node in Context.material.canvas.nodes) {
 			if (node.type == "RGB" ) {
-				var color = Project.raw.swatches[index].base;
-				node.outputs[0].default_value = [color.R, color.G, color.B, color.A];
+				node.outputs[0].default_value = [swatch.base.R, swatch.base.G, swatch.base.B, swatch.base.A];
 			}
 		}
 		Project.materials.push(Context.material);

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -9,7 +9,21 @@ import arm.ProjectFormat;
 
 class TabSwatches {
 
-	public static var empty: kha.Image = null;
+	public static var empty(get, default): kha.Image = null;
+
+	public static function get_empty() {
+		if (empty == null) {
+			var b = haxe.io.Bytes.alloc(4);
+			b.set(0, 255);
+			b.set(1, 255);
+			b.set(2, 255);
+			b.set(3, 255);
+			empty = kha.Image.fromBytes(b, 1, 1);
+		}
+		return empty;
+	}
+
+	private static var dragPosition : Int = -1;
 
 	@:access(zui.Zui)
 	public static function draw() {
@@ -64,7 +78,10 @@ class TabSwatches {
 			var statusw = kha.System.windowWidth() - UIToolbar.inst.toolbarw - Config.raw.layout[LayoutSidebarW];
 			var slotw = Std.int(26 * ui.SCALE());
 			var num = Std.int(statusw / (slotw + 3));
+			var dragPositionSet = false;
 
+			var uix = 0.0;
+			var uiy = 0.0;
 			for (row in 0...Std.int(Math.ceil(Project.raw.swatches.length / num))) {
 				ui.row([for (i in 0...num) 1 / num]);
 
@@ -84,26 +101,28 @@ class TabSwatches {
 						ui.fill(-2, -2, w, w, ui.t.HIGHLIGHT_COL);
 					}
 
-					if (empty == null) {
-						var b = haxe.io.Bytes.alloc(4);
-						b.set(0, 255);
-						b.set(1, 255);
-						b.set(2, 255);
-						b.set(3, 255);
-						empty = kha.Image.fromBytes(b, 1, 1);
+					uix = ui._x;
+					uiy = ui._y;
+
+					// Draw the drag position indicator
+					if (App.dragSwatch != null && dragPosition == i) {
+						ui.fill(-1, -2 , 2, 32, ui.t.HIGHLIGHT_COL);
 					}
 
-					var uix = ui._x;
-					var uiy = ui._y;
 					var state = ui.image(empty, Project.raw.swatches[i].base, slotw);
 
 					if (state == State.Started) {
 						Context.setSwatch(Project.raw.swatches[i]);
 
 						var mouse = Input.getMouse();
-						App.dragOffX = -(mouse.x - uix - ui._windowX - 3);
+						App.dragOffX = -(mouse.x - uix - ui._windowX - 2 * slotw);
 						App.dragOffY = -(mouse.y - uiy - ui._windowY + 1);
 						App.dragSwatch = Context.swatch;
+					}
+					else if (state == State.Hovered) {
+						var mouse = Input.getMouse();
+						dragPosition = (mouse.x > uix + ui._windowX + slotw / 2) ? i + 1 : i; // Switch to the next position if the mouse crosses the swatch rectangle center
+						dragPositionSet = true;
 					}
 					else if (state == State.Released) {
 						if (Time.time() - Context.selectTime < 0.25) {
@@ -152,12 +171,40 @@ class TabSwatches {
 				}
 			}
 
+			// Draw the rightmost line next to the last swatch.
+			if (App.dragSwatch != null && dragPosition == Project.raw.swatches.length) {
+				ui._x = uix; // Reset the position because otherwise it would start in the row below
+				ui._y = uiy;
+				ui.fill(28, -2, 2, 32, ui.t.HIGHLIGHT_COL);
+			}
+
+			// Currently there is no valid dragPosition so reset it.
+			if (!dragPositionSet)
+				dragPosition = -1;
+
 			var inFocus = ui.inputX > ui._windowX && ui.inputX < ui._windowX + ui._windowW &&
 						  ui.inputY > ui._windowY && ui.inputY < ui._windowY + ui._windowH;
 			if (inFocus && ui.isDeleteDown && Project.raw.swatches.length > 1) {
 				ui.isDeleteDown = false;
 				deleteSwatch(Context.swatch);
 			}
+		}
+	}
+
+	public static function acceptSwatchDrag(swatch : TSwatchColor) {
+		// No valid position available
+		if (TabSwatches.dragPosition == -1) return;
+
+		var swatchPosition = Project.raw.swatches.indexOf(swatch);
+		// A new swatch from color picker.
+		if (swatchPosition == -1) { 
+			Project.raw.swatches.insert(dragPosition, swatch);
+		}
+		else if (Math.abs(swatchPosition - dragPosition) > 0) { // Existing swatch is reordered
+			Project.raw.swatches.remove(swatch);
+			// If the new position is after the old one, decrease by one because the swatch has been deleted.
+			var newPosition = dragPosition - swatchPosition > 0 ? dragPosition -1 : dragPosition;
+			Project.raw.swatches.insert(newPosition, swatch);
 		}
 	}
 

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -71,6 +71,7 @@ class UIHeader {
 					App.dragOffY = -(mouse.y - uiy - ui._windowY + 1);
 					App.dragSwatch = Project.makeSwatch(h.color.value);
 				}
+				if (ui.isHovered) ui.tooltip(tr("Drag and drop picked color to swatches, materials, layers or to the node editor."));
 				if (ui.isHovered && ui.inputReleased) {
 					UIMenu.draw(function(ui) {
 						ui.fill(0, 0, ui._w / ui.ops.scaleFactor, ui.t.ELEMENT_H * 9, ui.t.SEPARATOR_COL);
@@ -85,7 +86,7 @@ class UIHeader {
 					Project.raw.swatches.push(newSwatch);
 					UIStatus.inst.statusHandle.redraws = 1;
 				}
-				if (ui.isHovered) ui.tooltip(tr("Add picker color to swatches"));
+				if (ui.isHovered) ui.tooltip(tr("Add picked color to swatches"));
 
 				ui.text(tr("Base") + ' ($baseRPicked,$baseGPicked,$baseBPicked)');
 				ui.text(tr("Normal") + ' ($normalRPicked,$normalGPicked,$normalBPicked)');

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -4,10 +4,12 @@ import kha.System;
 import zui.Zui;
 import zui.Id;
 import iron.RenderPath;
+import iron.system.Input;
 import arm.node.MakeMaterial;
 import arm.util.UVUtil;
 import arm.util.RenderUtil;
 import arm.io.ImportFont;
+import arm.ProjectFormat.TSwatchColor;
 import arm.Enums;
 
 class UIHeader {
@@ -60,7 +62,15 @@ class UIHeader {
 				h.color.R = baseRPicked;
 				h.color.G = baseGPicked;
 				h.color.B = baseBPicked;
-				ui.text("", 0, h.color);
+				var state = ui.text("", 0, h.color);
+				if (state == State.Started) {
+					var mouse = Input.getMouse();
+					var uix = ui._x;
+					var uiy = ui._y;
+					App.dragOffX = -(mouse.x - uix - ui._windowX - 3);
+					App.dragOffY = -(mouse.y - uiy - ui._windowY + 1);
+					App.dragSwatch = Project.makeSwatch(h.color.value);
+				}
 				if (ui.isHovered && ui.inputReleased) {
 					UIMenu.draw(function(ui) {
 						ui.fill(0, 0, ui._w / ui.ops.scaleFactor, ui.t.ELEMENT_H * 9, ui.t.SEPARATOR_COL);

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -17,6 +17,7 @@ import arm.util.RenderUtil;
 import arm.ui.UIHeader;
 import arm.Enums;
 import arm.Project;
+import arm.ProjectFormat.TSwatchColor;
 
 @:access(zui.Zui)
 @:access(zui.Nodes)
@@ -1003,12 +1004,11 @@ class UINodes {
 		getNodes().nodesSelected = [n];
 	}
 
-	public function acceptSwatchDrag(index: Int) {
+	public function acceptSwatchDrag(swatch : TSwatchColor) {
 		pushUndo();
 		var g = groupStack.length > 0 ? groupStack[groupStack.length - 1] : null;
 		var n = NodesMaterial.createNode("RGB", g);
-		var color = Project.raw.swatches[index].base;
-		n.outputs[0].default_value = [color.R, color.G, color.B, color.A];
+		n.outputs[0].default_value = [swatch.base.R, swatch.base.G, swatch.base.B, swatch.base.A];
 		getNodes().nodesSelected = [n];
 	}
 


### PR DESCRIPTION
This PR implements two features
1. A drag and drop feature for swatches inside the Swatches Tab, i.e. swatches can be reordered now.
2. A drag and drop feature for the picker tool. The picked color can be dragged and dropped now, i.e. it is possible to drag and drop the currently picked value into the swatches tab but it is also easily create fill layers and materials from the picked value. I think this is a very cool feature and removes the need to create a swatch that can be dragged and dropped to materials or layers.

In theory we could remove the "Add swatch" button now. On the one hadn this makes the ui simpler on the other hand it is a great way to quickly add swatches and easy to understand for users. To be honest I do not really like the button that much. Maybe an icon containing a swatch symbol and a plus sign would be better, but I'm no skilled icon designer 😎

1. Question: In theory it would be very easy now to generalize the swatches even further. The color picker above could not only include the color information but also all other picked values. Doing so would allow to drag these "god swatches" to materials and build materials with all other channels, too.
I.e.
```
if (node.type == "OUTPUT_MATERIAL_PBR") {
				node.inputs[1].default_value = swatch.opacity;
				node.inputs[2].default_value = swatch.occlusion;
				node.inputs[3].default_value = swatch.roughness;
				node.inputs[4].default_value = swatch.metallic;
				node.inputs[5].default_value[0] = swatch.normal.R;
				node.inputs[5].default_value[1] = swatch.normal.G;
				node.inputs[5].default_value[2] = swatch.normal.B;
				node.inputs[7].default_value = swatch.height;
			}
```
Add this to `acceptSwatchDrag` in TabMaterials. It would have the advantage of being more powerful but it also does not completely match the current swatch situation. The question boils down to the question whether this is the proper pbr swatch generalization or not. If one wanted to do that 
1. Double clicking a swatch should reveal the other channels, too. (Easily doable)
2. Maybe also change the swatch colors in the Swatches tab to have a material like appearance that shows metallic, roughness, ... A downside would be that colors are not easily comparable anymore which in turn could be compensated by giving the user a dropdown to switch between base color swatch view and "pbr" view.

2. Question: I also experimented with keyboard shortcuts to navigate through the swatches. To this end I added an update method to TabSwatches calles from UISidebar. the implementation looks like this:
```
public static function update() {
		//...

		if (kb.started("delete") && Project.raw.swatches.length > 1) {
				deleteSwatch(Context.swatch);
		}

		var index = Project.raw.swatches.indexOf(Context.swatch);
			
		if (kb.down("control") && kb.started("left") && index > 0) {
			Project.raw.swatches[index] = Project.raw.swatches[index - 1];
			Project.raw.swatches[index - 1] = Context.swatch;
		}
		else if (kb.down("control") && kb.started("right") && index < Project.raw.swatches.length-1) {
			Project.raw.swatches[index] = Project.raw.swatches[index + 1];
			Project.raw.swatches[index + 1] = Context.swatch;
		}
		else if (kb.started("left") && index > 0) {
			Context.swatch = Project.raw.swatches[index-1];
		}
		else if (kb.started("right") && index < Project.raw.swatches.length-1) {
			Context.swatch = Project.raw.swatches[index+1];
		}
```