### PR TITLE
Add tooltips at various places

### DIFF
--- a/Sources/arm/ui/TabBrushes.hx
+++ b/Sources/arm/ui/TabBrushes.hx
@@ -102,7 +102,7 @@ class TabBrushes {
 								iron.App.notifyOnInit(_init);
 							}
 
-							if (Project.brushes.length > 1 && ui.button(tr("Delete"), Left)) {
+							if (Project.brushes.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteBrush(Project.brushes[i]);
 							}
 						}, 3 + add);

--- a/Sources/arm/ui/TabFonts.hx
+++ b/Sources/arm/ui/TabFonts.hx
@@ -98,7 +98,7 @@ class TabFonts {
 						UIMenu.draw(function(ui: Zui) {
 							ui.text(fontName, Right, ui.t.HIGHLIGHT_COL);
 
-							if (Project.fonts.length > 1 && ui.button(tr("Delete"), Left) && Project.fonts[i].file != "") {
+							if (Project.fonts.length > 1 && ui.button(tr("Delete"), Left, "delete") && Project.fonts[i].file != "") {
 								deleteFont(Project.fonts[i]);
 							}
 						}, 1 + add);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -543,7 +543,7 @@ class TabLayers {
 			}
 
 			ui.enabled = canDelete(l);
-			if (ui.button(tr("Delete"), Left)) {
+			if (ui.button(tr("Delete"), Left, "delete")) {
 				deleteLayer(l);
 			}
 			ui.enabled = true;

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -138,7 +138,7 @@ class TabMaterials {
 								iron.App.notifyOnInit(_init);
 							}
 
-							if (Project.materials.length > 1 && ui.button(tr("Delete"), Left)) {
+							if (Project.materials.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteMaterial(m);
 							}
 

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -139,7 +139,7 @@ class TabSwatches {
 								Krom.copyToClipboard(untyped val.toString(16));
 							}
 							#end
-							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left)) {
+							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteSwatch(Project.raw.swatches[i]);
 							}
 						}, 2 + add);

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -132,7 +132,7 @@ class TabTextures {
 										Layers.createImageMask(asset);
 									});
 								}
-								if (ui.button(tr("Delete"), Left)) {
+								if (ui.button(tr("Delete"), Left, "delete")) {
 									deleteTexture(asset);
 								}
 								if (!isPacked && ui.button(tr("Open Containing Directory..."), Left)) {

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -141,6 +141,8 @@ class UIMenu {
 				}
 				menuAlign(ui);
 				Context.envmapAngle = ui.slider(envaHandle, tr("Environment Angle"), 0.0, 360.0, true, 1) / 180.0 * Math.PI;
+				if (ui.isHovered) ui.tooltip(tr("{shortcut} and move mouse", ["shortcut" => Config.keymap.rotate_envmap]));
+
 				if (envaHandle.changed) Context.ddirty = 2;
 
 				if (Scene.active.lights.length > 0) {
@@ -167,6 +169,8 @@ class UIMenu {
 					menuAlign(ui);
 					var lightAngle = lahandle.value;
 					ui.slider(lahandle, tr("Light Angle"), 0.0, 360.0, true, 1);
+					if (ui.isHovered) ui.tooltip(tr("{shortcut} and move mouse", ["shortcut" => Config.keymap.rotate_light]));
+
 					var ldiff = lahandle.value - lightAngle;
 					if (ldiff != 0) {
 						ldiff = (ldiff) / 180.0 * Math.PI;

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -354,7 +354,15 @@ class UIMenu {
 
 				menuFill(ui);
 				menuAlign(ui);
-				Context.cameraControls = Ext.inlineRadio(ui, Id.handle({ position: Context.cameraControls }), [tr("Orbit"), tr("Rotate"), tr("Fly")], Left);
+				var orbitAndRotateTooltip = tr("{rotate_shortcut} or move right mouse button to rotate.\n{zoom_shortcut} or scroll to zoom.\n{pan_shortcut} or move middle mouse to pan.", 
+					["rotate_shortcut" => Config.keymap.action_rotate, 
+					"zoom_shortcut" => Config.keymap.action_zoom,  
+					"pan_shortcut" => Config.keymap.action_pan,
+					]);
+
+				var flyTooltip = tr("Hold the right mouse button and one of the following commands:\n move mouse to rotate.\nw, up or scroll up to move forward.\n s, down or scroll down to move backward.\na or left to move left.\nd or right to move right.\ne to move up.\nq to move down.\nHold shift to move faster or alt to move slower.");
+				var shortcuts = [orbitAndRotateTooltip, orbitAndRotateTooltip, flyTooltip];
+				Context.cameraControls = Ext.inlineRadio(ui, Id.handle({ position: Context.cameraControls }), [tr("Orbit"), tr("Rotate"), tr("Fly")], Left, shortcuts);
 
 				menuFill(ui);
 				menuAlign(ui);


### PR DESCRIPTION
Currently the shortcuts for the camera controls are hardly accessible to the user. For orbit and rotate the user has to check the shortcuts in the preferences dialog box and for fly the source code has to be read.  See also https://github.com/armory3d/armorbase/pull/17

In addition I added tooltips for delete in tabs, materials, layers, swatches, textures, ...