### PR TITLE
Improve texture tab

### DIFF
--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -907,8 +907,8 @@ class Layers {
 
 	public static function createImageMask(asset: TAsset) {
 		var l = Context.layer;
-		if (l.isMask() || l.isGroup()) {
-			return;
+		if (l.isMask()) {
+			l = l.parent;
 		}
 
 		History.newLayer();

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -132,6 +132,11 @@ class TabTextures {
 										Layers.createImageMask(asset);
 									});
 								}
+								if (ui.button(tr("Set as envmap"), Left)) {
+									App.notifyOnNextFrame(function() {
+									arm.io.ImportEnvmap.run(asset.file, img);
+									});
+								}
 								if (ui.button(tr("Delete"), Left)) {
 									deleteTexture(asset);
 								}
@@ -141,7 +146,7 @@ class TabTextures {
 								if (!isPacked && ui.button(tr("Open in Browser"), Left)) {
 									TabBrowser.showDirectory(asset.file.substr(0, asset.file.lastIndexOf(Path.sep)));
 								}
-							}, isPacked ? 5 : 7);
+							}, isPacked ? 6 : 8);
 						}
 
 						if (Config.raw.show_asset_names) {


### PR DESCRIPTION
Improved the textures tab
1. The "To mask" command did only work if a layer was selected and not for masks and groups. Now it is possible in all cases.
2. ArmorPaint had no obvious way of setting an envmap of an already imported texture. Thus I added a context entry to do so. I allowed it for all image formats, not just hdr. Please tell me if this option should be restricted to hdr images.