### PR TITLE
Improve layers

### DIFF
--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -141,13 +141,13 @@ class History {
 				Context.layer.swap(lay);
 				Context.layerPreviewDirty = true;
 			}
-			else if (step.name == tr("To Fill Layer")) {
+			else if (step.name == tr("To Fill Layer") || step.name == tr("To Fill Mask")) {
 				Context.layer.toPaintLayer();
 				undoI = undoI - 1 < 0 ? Config.raw.undo_steps - 1 : undoI - 1;
 				var lay = undoLayers[undoI];
 				Context.layer.swap(lay);
 			}
-			else if (step.name == tr("To Paint Layer")) {
+			else if (step.name == tr("To Paint Layer") || step.name == tr("To Paint Mask")) {
 				undoI = undoI - 1 < 0 ? Config.raw.undo_steps - 1 : undoI - 1;
 				var lay = undoLayers[undoI];
 				Context.layer.swap(lay);
@@ -303,13 +303,13 @@ class History {
 				Context.layerPreviewDirty = true;
 				undoI = (undoI + 1) % Config.raw.undo_steps;
 			}
-			else if (step.name == tr("To Fill Layer")) {
+			else if (step.name == tr("To Fill Layer") || step.name == tr("To Fill Mask")) {
 				var lay = undoLayers[undoI];
 				Context.layer.swap(lay);
 				Context.layer.fill_layer = Project.materials[step.material];
 				undoI = (undoI + 1) % Config.raw.undo_steps;
 			}
-			else if (step.name == tr("To Paint Layer")) {
+			else if (step.name == tr("To Paint Layer") || step.name == tr("To Paint Mask")) {
 				Context.layer.toPaintLayer();
 				var lay = undoLayers[undoI];
 				Context.layer.swap(lay);
@@ -451,13 +451,23 @@ class History {
 	}
 
 	public static function toFillLayer() {
-		copyToUndo(Context.layer.id, undoI, Context.layer.isMask());
+		copyToUndo(Context.layer.id, undoI, false);
 		push(tr("To Fill Layer"));
 	}
 
+	public static function toFillMask() {
+		copyToUndo(Context.layer.id, undoI, true);
+		push(tr("To Fill Mask"));
+	}
+
 	public static function toPaintLayer() {
-		copyToUndo(Context.layer.id, undoI, Context.layer.isMask());
+		copyToUndo(Context.layer.id, undoI, false);
 		push(tr("To Paint Layer"));
+	}
+
+	public static function toPaintMask() {
+		copyToUndo(Context.layer.id, undoI, true);
+		push(tr("To Paint Mask"));
 	}
 
 	public static function layerOpacity() {

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -26,7 +26,7 @@ class History {
 			var active = steps.length - 1 - redos;
 			var step = steps[active];
 
-			if (step.name == tr("New Layer")) {
+			if (step.name == tr("New Layer") || step.name == tr("New Black Mask") || step.name == tr("New White Mask") || step.name == tr("New Fill Mask")) {
 				Context.layer = Project.layers[step.layer];
 				Context.layer.delete();
 			}
@@ -208,10 +208,27 @@ class History {
 			var active = steps.length - redos;
 			var step = steps[active];
 
-			if (step.name == tr("New Layer")) {
+			if (step.name == tr("New Layer") || step.name == tr("New Black Mask") || step.name == tr("New White Mask") || step.name == tr("New Fill Mask")) {
 				var parent = step.layer_parent > 0 ? Project.layers[step.layer_parent - 1] : null;
 				var l = new LayerSlot("", step.layer_type, parent);
 				Project.layers.insert(step.layer, l);
+				if (step.name == tr("New Black Mask")) {
+					App.notifyOnNextFrame(function() {
+						l.clear(0x00000000);
+					});
+				}
+				else if (step.name == tr("New White Mask")) {
+					App.notifyOnNextFrame(function() {
+						l.clear(0xffffffff);
+					});
+				}
+				else if (step.name == tr("New Fill Mask")) {
+					App.notifyOnNextFrame(function() {
+						Context.material = Project.materials[step.material];
+						l.toFillLayer();
+					});
+				}
+				Context.layerPreviewDirty = true;
 				Context.setLayer(l);
 			}
 			else if (step.name == tr("New Group")) {
@@ -370,6 +387,18 @@ class History {
 		push(tr("New Layer"));
 	}
 	
+	public static function newBlackMask() {
+		push(tr("New Black Mask"));
+	}
+
+	public static function newWhiteMask() {
+		push(tr("New White Mask"));
+	}
+
+	public static function newFillMask() {
+		push(tr("New Fill Mask"));
+	}
+
 	public static function newGroup() {
 		push(tr("New Group"));
 	}

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -29,6 +29,7 @@ class History {
 			if (step.name == tr("New Layer") || step.name == tr("New Black Mask") || step.name == tr("New White Mask") || step.name == tr("New Fill Mask")) {
 				Context.layer = Project.layers[step.layer];
 				Context.layer.delete();
+				Context.layer = Project.layers[step.layer > 0 ? step.layer - 1 : 0];
 			}
 			else if (step.name == tr("New Group")) {
 				Context.layer = Project.layers[step.layer];
@@ -36,6 +37,7 @@ class History {
 				// The layer below is the only layer in the group. Its layer masks are automatically unparented, too.
 				Project.layers[step.layer - 1].parent = null;
 				Context.layer.delete();
+				Context.layer = Project.layers[step.layer > 0 ? step.layer - 1 : 0];
 			}
 			else if (step.name == tr("Delete Layer")) {
 				var parent = step.layer_parent > 0 ? Project.layers[step.layer_parent - 1] : null;

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -30,6 +30,13 @@ class History {
 				Context.layer = Project.layers[step.layer];
 				Context.layer.delete();
 			}
+			else if (step.name == tr("New Group")) {
+				Context.layer = Project.layers[step.layer];
+				Console.info(Context.layer.name);
+				// The layer below is the only layer in the group. Its layer masks are automatically unparented, too.
+				Project.layers[step.layer - 1].parent = null;
+				Context.layer.delete();
+			}
 			else if (step.name == tr("Delete Layer")) {
 				var parent = step.layer_parent > 0 ? Project.layers[step.layer_parent - 1] : null;
 				var l = new LayerSlot("", step.layer_type, parent);
@@ -207,6 +214,14 @@ class History {
 				Project.layers.insert(step.layer, l);
 				Context.setLayer(l);
 			}
+			else if (step.name == tr("New Group")) {
+				var l = Project.layers[step.layer - 1];
+				var group = Layers.newGroup();
+				Project.layers.remove(group);
+				Project.layers.insert(step.layer, group);
+				l.parent = group;
+				Context.setLayer(group);
+			}
 			else if (step.name == tr("Delete Layer")) {
 				Context.layer = Project.layers[step.layer];
 				swapActive();
@@ -353,6 +368,10 @@ class History {
 
 	public static function newLayer() {
 		push(tr("New Layer"));
+	}
+	
+	public static function newGroup() {
+		push(tr("New Group"));
 	}
 
 	public static function duplicateLayer() {

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -73,7 +73,12 @@ class History {
 				Context.layerPreviewDirty = true;
 			}
 			else if (step.name == tr("Duplicate Layer")) {
-				Context.layer = Project.layers[step.layer + 1];
+				var children = Project.layers[step.layer].getRecursiveChildren();
+				var position = step.layer + 1;
+				if (children != null)
+					position += children.length;
+
+				Context.layer = Project.layers[position];
 				Context.layer.delete();
 			}
 			else if (step.name == tr("Order Layers")) {
@@ -266,7 +271,10 @@ class History {
 			}
 			else if (step.name == tr("Duplicate Layer")) {
 				Context.layer = Project.layers[step.layer];
-				Context.layer = Context.layer.duplicate();
+				function _next() {
+					Layers.duplicateLayer(Context.layer);
+				}
+				App.notifyOnNextFrame(_next);
 			}
 			else if (step.name == tr("Order Layers")) {
 				var target = Project.layers[step.prev_order];

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -116,6 +116,13 @@ class History {
 				Context.layersPreviewDirty = true;
 				Context.setLayer(Context.layer);
 			}
+			else if (step.name == tr("Invert Mask")) {
+				function _next() {
+					Context.layer = Project.layers[step.layer];
+					Context.layer.invertMask();
+				}
+				iron.App.notifyOnInit(_next);
+			}
 			else if (step.name == "Apply Filter") {
 				undoI = undoI - 1 < 0 ? Config.raw.undo_steps - 1 : undoI - 1;
 				var lay = undoLayers[undoI];
@@ -246,6 +253,13 @@ class History {
 				}
 				App.notifyOnNextFrame(_next);
 			}
+			else if (step.name == tr("Invert Mask")) {
+				function _next() {
+					Context.layer = Project.layers[step.layer];
+					Context.layer.invertMask();
+				}
+				iron.App.notifyOnInit(_next);
+			}
 			else if (step.name == tr("Apply Filter")) {
 				var lay = undoLayers[undoI];
 				Context.setLayer(Project.layers[step.layer]);
@@ -373,6 +387,11 @@ class History {
 	public static function applyMask() {
 		copyToUndo(Context.layer.id, undoI, true);
 		push(tr("Apply Mask"));
+	}
+
+	
+	public static function invertMask() {
+		push(tr("Invert Mask"));
 	}
 
 	@:keep

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -370,6 +370,65 @@ class Layers {
 		}
 	}
 
+	public static function duplicateLayer(l: LayerSlot) {
+		if (!l.isGroup()) {
+			Context.setLayer(l);
+			History.duplicateLayer();
+			var newLayer = l.duplicate();
+			Context.setLayer(newLayer);
+			var masks = l.getMasks(false);
+			if (masks != null) {
+				for (m in masks) {
+					Context.setLayer(m);
+					History.duplicateLayer();
+					m = m.duplicate();
+					m.parent = newLayer;
+					Project.layers.remove(m);
+					Project.layers.insert(Project.layers.indexOf(newLayer), m);
+				}
+			}
+			Context.setLayer(newLayer);
+		}
+		else {
+			// TODO: add undo-redo support for creating a new group
+			var newGroup = Layers.newGroup();
+			Project.layers.remove(newGroup);
+			Project.layers.insert(Project.layers.indexOf(l) + 1, newGroup);
+			// group.show_panel = true;
+			for (c in l.getChildren()) {
+				var masks = c.getMasks(false);
+				Context.setLayer(c);
+				History.duplicateLayer();
+				var newLayer = c.duplicate();
+				newLayer.parent = newGroup;
+				Project.layers.remove(newLayer);
+				Project.layers.insert(Project.layers.indexOf(newGroup), newLayer);
+				if (masks != null) {
+					for (m in masks) {
+						Context.setLayer(m);
+						History.duplicateLayer();
+						var newMask = m.duplicate();
+						newMask.parent = newLayer;
+						Project.layers.remove(newMask);
+						Project.layers.insert(Project.layers.indexOf(newLayer), newMask);
+					}
+				}
+			}
+			var groupMasks = l.getMasks();
+			if (groupMasks != null) {
+				for (m in groupMasks) {
+					Context.setLayer(m);
+					History.duplicateLayer();
+					var newMask = m.duplicate();
+					newMask.parent = newGroup;
+					Project.layers.remove(newMask);
+					Project.layers.insert(Project.layers.indexOf(newGroup), newMask);
+				}
+			}
+			Context.setLayer(newGroup);
+		}
+	}
+
 	public static function applyMasks(l: LayerSlot) {
 		var masks = l.getMasks();
 
@@ -907,8 +966,8 @@ class Layers {
 
 	public static function createImageMask(asset: TAsset) {
 		var l = Context.layer;
-		if (l.isMask()) {
-			l = l.parent;
+		if (l.isMask() || l.isGroup()) {
+			return;
 		}
 
 		History.newLayer();

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -372,15 +372,11 @@ class Layers {
 
 	public static function duplicateLayer(l: LayerSlot) {
 		if (!l.isGroup()) {
-			Context.setLayer(l);
-			History.duplicateLayer();
 			var newLayer = l.duplicate();
 			Context.setLayer(newLayer);
 			var masks = l.getMasks(false);
 			if (masks != null) {
 				for (m in masks) {
-					Context.setLayer(m);
-					History.duplicateLayer();
 					m = m.duplicate();
 					m.parent = newLayer;
 					Project.layers.remove(m);
@@ -390,23 +386,18 @@ class Layers {
 			Context.setLayer(newLayer);
 		}
 		else {
-			// TODO: add undo-redo support for creating a new group
 			var newGroup = Layers.newGroup();
 			Project.layers.remove(newGroup);
 			Project.layers.insert(Project.layers.indexOf(l) + 1, newGroup);
 			// group.show_panel = true;
 			for (c in l.getChildren()) {
 				var masks = c.getMasks(false);
-				Context.setLayer(c);
-				History.duplicateLayer();
 				var newLayer = c.duplicate();
 				newLayer.parent = newGroup;
 				Project.layers.remove(newLayer);
 				Project.layers.insert(Project.layers.indexOf(newGroup), newLayer);
 				if (masks != null) {
 					for (m in masks) {
-						Context.setLayer(m);
-						History.duplicateLayer();
 						var newMask = m.duplicate();
 						newMask.parent = newLayer;
 						Project.layers.remove(newMask);
@@ -417,8 +408,6 @@ class Layers {
 			var groupMasks = l.getMasks();
 			if (groupMasks != null) {
 				for (m in groupMasks) {
-					Context.setLayer(m);
-					History.duplicateLayer();
 					var newMask = m.duplicate();
 					newMask.parent = newGroup;
 					Project.layers.remove(newMask);

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -921,10 +921,11 @@ class Layers {
 		return l;
 	}
 
-	public static function newMask(clear = true, parent: LayerSlot): LayerSlot {
+	public static function newMask(clear = true, parent: LayerSlot, position = -1): LayerSlot {
 		if (Project.layers.length > maxLayers) return null;
 		var l = new LayerSlot("", SlotMask, parent);
-		Project.layers.insert(Project.layers.indexOf(parent), l);
+		if (position == -1) position = Project.layers.indexOf(parent);
+		Project.layers.insert(position, l);
 		Context.setLayer(l);
 		if (clear) iron.App.notifyOnInit(function() { l.clear(); });
 		Context.layerPreviewDirty = true;

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -533,22 +533,24 @@ class TabLayers {
 				}
 			}
 
-			var toFillString = l.isLayer() ? tr("To Fill Layer") : tr("To Fill Mask");
-			var toPaintString = l.isLayer() ? tr("To Paint Layer") : tr("To Paint Mask");
+			if (!l.isGroup()) {
+				var toFillString = l.isLayer() ? tr("To Fill Layer") : tr("To Fill Mask");
+				var toPaintString = l.isLayer() ? tr("To Paint Layer") : tr("To Paint Mask");
 
-			if (!l.isGroup() && l.fill_layer == null && ui.button(toFillString, Left)) {
-				function _init() {
-					History.toFillLayer();
-					l.toFillLayer();
+				if (l.fill_layer == null && ui.button(toFillString, Left)) {
+					function _init() {
+						l.isLayer() ? History.toFillLayer() : History.toFillMask();
+						l.toFillLayer();
+					}
+					iron.App.notifyOnInit(_init);
 				}
-				iron.App.notifyOnInit(_init);
-			}
-			if (!l.isGroup() && l.fill_layer != null && ui.button(toPaintString, Left)) {
-				function _init() {
-					History.toPaintLayer();
-					l.toPaintLayer();
+				if (l.fill_layer != null && ui.button(toPaintString, Left)) {
+					function _init() {
+						l.isLayer() ? History.toPaintLayer() : History.toPaintMask();
+						l.toPaintLayer();
+					}
+					iron.App.notifyOnInit(_init);
 				}
-				iron.App.notifyOnInit(_init);
 			}
 
 			ui.enabled = canDelete(l);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -623,49 +623,7 @@ class TabLayers {
 			ui.enabled = true;
 			if (ui.button(tr("Duplicate"), Left)) {
 				function _init() {
-					if (!l.isGroup()) {
-						var masks = l.getMasks();
-						Context.setLayer(l);
-						History.duplicateLayer();
-						l = l.duplicate();
-						Context.setLayer(l);
-						if (masks != null) {
-							for (m in masks) {
-								Context.setLayer(m);
-								History.duplicateLayer();
-								m = m.duplicate();
-								m.parent = l;
-								Project.layers.remove(m);
-								Project.layers.insert(Project.layers.indexOf(l), m);
-							}
-						}
-					}
-					else {
-						var group = Layers.newGroup();
-						Project.layers.remove(group);
-						Project.layers.insert(Project.layers.indexOf(l) + 1, group);
-						// group.show_panel = true;
-						for (c in l.getChildren()) {
-							var masks = c.getMasks();
-							Context.setLayer(c);
-							History.duplicateLayer();
-							c = c.duplicate();
-							c.parent = group;
-							Project.layers.remove(c);
-							Project.layers.insert(Project.layers.indexOf(group), c);
-							if (masks != null) {
-								for (m in masks) {
-									Context.setLayer(m);
-									History.duplicateLayer();
-									m = m.duplicate();
-									m.parent = c;
-									Project.layers.remove(m);
-									Project.layers.insert(Project.layers.indexOf(c), m);
-								}
-							}
-						}
-						Context.setLayer(group);
-					}
+					Layers.duplicateLayer(l);
 				}
 				iron.App.notifyOnInit(_init);
 			}

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -490,20 +490,21 @@ class TabLayers {
 		}
 	}
 
+	static function canMergeDown(l: LayerSlot) : Bool {
+		var index = Project.layers.indexOf(l);
+		// Lowest layer
+		if (index == 0) return false;
+		// Lowest layer that has masks
+		if (l.isLayer() && Project.layers[0].isMask() && Project.layers[0].parent == l) return false;
+		// The lowest toplevel layer is a group
+		if (l.isGroup() && Project.layers[0].isInGroup() && Project.layers[0].getContainingGroup() == l) return false;
+		// Masks must be merged down to masks
+		if (l.isMask() && !Project.layers[index - 1].isMask()) return false;
+		return true;
+	}
+
 	static function drawLayerContextMenu(l: LayerSlot) {
 		var add = 0;
-		var li = Project.layers.indexOf(l);
-		var canMergeDown = li > 0 && (l.isGroup() || l.isLayer() || (l.isMask() && Project.layers[li - 1].isMask()));
-		if (l.isLayer() && l.hasMasks() && li == l.getMasks().length) canMergeDown = false; // First layer
-
-		// Is the current group the first group?
-		var firstGroup = true;
-		for (i in 0...li - 1) {
-			if (!Project.layers[i].isMask() && Project.layers[i].parent != l) {
-				firstGroup = false;
-			}
-		}
-		if (l.isGroup() && firstGroup) canMergeDown = false;
 
 		if (l.fill_layer == null) add += 1; // Clear
 		if (l.fill_layer != null && !l.isMask()) add += 3;
@@ -609,7 +610,7 @@ class TabLayers {
 				}
 				iron.App.notifyOnInit(_init);
 			}
-			ui.enabled = canMergeDown;
+			ui.enabled = canMergeDown(l);
 			if (ui.button(tr("Merge Down"), Left)) {
 				function _init() {
 					Context.setLayer(l);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -592,21 +592,7 @@ class TabLayers {
 			}
 			if (l.isGroup() && ui.button(tr("Merge Group"), Left)) {
 				function _init() {
-					var children = l.getChildren();
-
-					if (children.length == 1 && children[0].hasMasks()) {
-						Layers.applyMasks(children[0]);
-					}
-
-					for (i in 0...children.length - 1) {
-						Context.setLayer(children[children.length - 1 - i]);
-						History.mergeLayers();
-						Layers.mergeDown();
-					}
-					children[0].parent = null;
-					children[0].name = l.name;
-					if (children[0].fill_layer != null) children[0].toPaintLayer();
-					l.delete();
+					Layers.mergeGroup(l);
 				}
 				iron.App.notifyOnInit(_init);
 			}

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -380,7 +380,10 @@ class TabLayers {
 						  ui.inputY > ui._windowY && ui.inputY < ui._windowY + ui._windowH;
 			if (inFocus && ui.isDeleteDown && canDelete(Context.layer)) {
 				ui.isDeleteDown = false;
-				deleteLayer(Context.layer);
+				function _init() {
+					deleteLayer(Context.layer);
+				}
+				iron.App.notifyOnInit(_init);
 			}
 		}
 		ui._y -= center;
@@ -550,7 +553,10 @@ class TabLayers {
 
 			ui.enabled = canDelete(l);
 			if (ui.button(tr("Delete"), Left, "delete")) {
-				deleteLayer(l);
+				function _init() {
+					deleteLayer(Context.layer);
+				}
+				iron.App.notifyOnInit(_init);
 			}
 			ui.enabled = true;
 

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -51,7 +51,7 @@ class TabLayers {
 						}
 						App.notifyOnNextFrame(_next);
 						Context.layerPreviewDirty = true;
-						History.newLayer();
+						History.newBlackMask();
 					}
 					if (ui.button(tr("White Mask"), Left)) {
 						if (l.isMask()) Context.setLayer(l.parent);
@@ -63,7 +63,7 @@ class TabLayers {
 						}
 						App.notifyOnNextFrame(_next);
 						Context.layerPreviewDirty = true;
-						History.newLayer();
+						History.newWhiteMask();
 					}
 					if (ui.button(tr("Fill Mask"), Left)) {
 						if (l.isMask()) Context.setLayer(l.parent);
@@ -75,7 +75,7 @@ class TabLayers {
 						}
 						iron.App.notifyOnInit(_init);
 						Context.layerPreviewDirty = true;
-						History.newLayer();
+						History.newFillMask();
 					}
 					ui.enabled = !Context.layer.isGroup() && !Context.layer.isInGroup();
 					if (ui.button(tr("Group"), Left)) {

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -575,6 +575,8 @@ class TabLayers {
 			}
 			if (l.isMask() && l.fill_layer == null && ui.button(tr("Invert"), Left)) {
 				function _init() {
+					Context.setLayer(l);
+					History.invertMask();
 					l.invertMask();
 				}
 				iron.App.notifyOnInit(_init);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -591,7 +591,7 @@ class TabLayers {
 			}
 			if (l.isMask() && ui.button(tr("Apply"), Left)) {
 				function _init() {
-					Context.setLayer(l);
+					Context.layer = l;
 					History.applyMask();
 					l.applyMask();
 					Context.setLayer(l.parent);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -619,6 +619,8 @@ class TabLayers {
 			ui.enabled = true;
 			if (ui.button(tr("Duplicate"), Left)) {
 				function _init() {
+					Context.setLayer(l);
+					History.duplicateLayer();
 					Layers.duplicateLayer(l);
 				}
 				iron.App.notifyOnInit(_init);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -77,8 +77,12 @@ class TabLayers {
 						Context.layerPreviewDirty = true;
 						History.newLayer();
 					}
-					if (ui.button(tr("Group"), Left) && !Context.layer.isGroup() && Context.layer.parent == null) {
-						if (l.parent != null || l.isGroup()) return;
+					ui.enabled = !Context.layer.isGroup() && !Context.layer.isInGroup();
+					if (ui.button(tr("Group"), Left)) {
+						if (l.isGroup() || l.isInGroup()) return;
+
+						if (l.isLayerMask()) l = l.parent;
+
 						var pointers = initLayerMap();
 						var group = Layers.newGroup();
 						Context.setLayer(l);
@@ -89,6 +93,7 @@ class TabLayers {
 						for (m in Project.materials) remapLayerPointers(m.canvas.nodes, fillLayerMap(pointers));
 						Context.setLayer(group);
 					}
+					ui.enabled = true;
 				}, 8);
 			}
 			if (ui.button(tr("2D View"))) UISidebar.inst.show2DView(View2DLayer);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -850,6 +850,8 @@ class TabLayers {
 	static function canDelete(l: LayerSlot) {
 		var numLayers = 0;
 
+		if (l.isMask()) return true;
+		
 		for (slot in Project.layers) {
 			if (slot.isLayer()) ++numLayers;
 		}

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -853,5 +853,4 @@ class TabLayers {
 		return numLayers > 1;
 	}
 
-	}
 }

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -89,9 +89,9 @@ class TabLayers {
 						Project.layers.remove(group);
 						Project.layers.insert(Project.layers.indexOf(l) + 1, group);
 						l.parent = group;
-						// History.newGroup();
 						for (m in Project.materials) remapLayerPointers(m.canvas.nodes, fillLayerMap(pointers));
 						Context.setLayer(group);
+						History.newGroup();
 					}
 					ui.enabled = true;
 				}, 8);


### PR DESCRIPTION
This PR tries to fix several issues related to layers and improves a few things.
1. New groups are not always available. Therefore it is better to grey out if not available.
2. Layer delete has several issues. It does not work well with group masks, the undo and redo system is broken and it was not possible to delete in all valid cases resp. there have been cases where deleting shouldn't have been available. This PR sorts them out and fixes  #989. Maybe my undo-redo approach is not the most efficient way but it works reliably as far as I can see.
3. Duplicate layers did not work well with group masks. Fixed these issues and refactored a bit.
4. canMergeDown could use a little bit of love to become more readable. Also it did not cover all cases I think.
5. Merging groups and merge down did not work reliably with group masks. Fixed these issues.
6. Mask invert could not be undone or redone. Implemented this
7. Creating a new group could not be undone or redone. Implemented this
8. Undo/redo for to fill mask or to paint mask had the more general to fill/paint layer labels. I improved this.

@luboslenco Please do not merge the PR yet. I'd like to sort out some more issues. The undo-redo for layer reordering is on the way. I only have to sort out a little issue that arises when the user collapses groups which is bad because this changes the behavior to add or not to add a layer to a group. At the moment you can expect that 

- #792 The non-linked issues there are fixed. The rearrange one is not pushed yet.
- #989 is fixed

1. Question: As you can see, I factored some methods out to make the code easier to read. Currently it is scattered around between TabLayers and Layers. Where should I put it? What about this distinction: LayerSlot.hx is the "dumb" one that does not know too much and does not know about undo-redo. The higher-order operations are implemented in Layers, know how to undo-redo and use LayerSlot. TabLayers will only be responsible for ui related stuff. 
2. I think the existing code is missing some `remapLayerPointers` isn't it? Whenever the indices change the pointers should be remapped, right? I guess there are some bugs to dig out. For instance what should happen if a layer disappears due to merging down.
3. `getMasks `is a bit strange for me. Why does it have the option to return all masks, including the group masks. Imho this is not the right behavior. I think one is probably never interested in all masks because both groups of masks do not play the same role. Second: I'd like to change the behavior to never return null but only to return an empty array if there is no mask. This would immediately remove all these null checks.
4. I think we have to think about the question what should happen if not all layers are shown because of the filter and what should happen if a group contains layers on varying meshes.

