### PR TITLE
Make light angle consistent with other angles

### DIFF
--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -160,10 +160,12 @@ class UIMenu {
 					var lahandle = Id.handle();
 					lahandle.value = Context.lightAngle / Math.PI * 180;
 					menuAlign(ui);
-					var newAngle = ui.slider(lahandle, tr("Light Angle"), 0.0, 359.0, true, 1) / 180 * Math.PI;
+					var newAngle = ui.slider(lahandle, tr("Light Angle"), 0.0, 360.0, true, 1) / 180 * Math.PI;
 					var ldiff = newAngle - Context.lightAngle;
 					if (Math.abs(ldiff) > 0.005) {
-						Context.lightAngle = newAngle % (2*Math.PI);
+						if (newAngle < 0) newAngle += (Std.int(-newAngle / (2 * Math.PI)) + 1) * 2 * Math.PI;
+						else if (newAngle > 2 * Math.PI) newAngle -= Std.int(newAngle / (2 * Math.PI)) * 2 * Math.PI;
+						Context.lightAngle = newAngle;
 						var m = iron.math.Mat4.identity();
 						m.self = kha.math.FastMatrix4.rotationZ(ldiff);
 						light.transform.local.multmat(m);


### PR DESCRIPTION
Now it behaves like the other angle sliders. Thank you for being critical. Consistency is important,
The angles are clamped to [0,2PI] now. I.e. Both values 0 and 360 degrees are valid. Did not change it for Camera.hx but it does not matter there because it is very unlikely that the user produces exactly 2*PI by dragging the mouse and even if this case happens there is no harm if the slider shows 0 the next time the user opens the viewport menu. I tried it and the nearest I could get to 2*PI was 359.89° by mouse and this rounds to 360 so the user will not experience any difference I guess.