### PR TITLE
Improve color id tool

### DIFF
--- a/Sources/arm/io/ImportAsset.hx
+++ b/Sources/arm/io/ImportAsset.hx
@@ -4,6 +4,7 @@ import arm.sys.Path;
 import arm.sys.File;
 import arm.ui.UINodes;
 import arm.ui.UIBox;
+import arm.ui.UIHeader;
 import arm.Project;
 
 class ImportAsset {
@@ -38,6 +39,10 @@ class ImportAsset {
 				UINodes.inst.acceptAssetDrag(assetIndex);
 				UINodes.inst.getNodes().nodesDrag = false;
 				UINodes.inst.hwnd.redraws = 2;
+			}
+			if (Context.tool == ToolColorId && Project.assetNames.length == 1) {
+				UIHeader.inst.headerHandle.redraws = 2;
+				Context.ddirty = 2;
 			}
 		}
 		else if (Path.isFont(path)) {

--- a/Sources/arm/node/brush/BrushOutputNode.hx
+++ b/Sources/arm/node/brush/BrushOutputNode.hx
@@ -1,5 +1,6 @@
 package arm.node.brush;
 
+import arm.ui.UIToolbar;
 import arm.ui.UISidebar;
 import arm.ui.UIView2D;
 import arm.Enums;
@@ -120,6 +121,7 @@ class BrushOutputNode extends LogicNode {
 			var down = iron.system.Input.getMouse().down() || iron.system.Input.getPen().down();
 			if (down && Context.tool == ToolColorId && Project.assets.length > 0) {
 				Context.colorIdPicked = true;
+				UIToolbar.inst.toolbarHandle.redraws = 1;
 			}
 
 			// Prevent painting the same spot

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -137,6 +137,15 @@ class TabTextures {
 										arm.io.ImportEnvmap.run(asset.file, img);
 									});
 								}
+								if (ui.button(tr("Set as Color ID Map"), Left)) {
+									Context.colorIdHandle.position = i;
+									Context.colorIdPicked = false;
+									UIToolbar.inst.toolbarHandle.redraws = 1;
+									if (Context.tool == ToolColorId) {
+										UIHeader.inst.headerHandle.redraws = 2;
+										Context.ddirty = 2;
+									}
+								}
 								if (ui.button(tr("Delete"), Left)) {
 									deleteTexture(asset);
 								}
@@ -146,7 +155,7 @@ class TabTextures {
 								if (!isPacked && ui.button(tr("Open in Browser"), Left)) {
 									TabBrowser.showDirectory(asset.file.substr(0, asset.file.lastIndexOf(Path.sep)));
 								}
-							}, isPacked ? 6 : 8);
+							}, isPacked ? 7 : 9);
 						}
 
 						if (Config.raw.show_asset_names) {

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -208,6 +208,13 @@ class TabTextures {
 			Context.texture = Project.assets[i == Project.assets.length - 1 ? i - 1 : i + 1];
 		}
 		UIStatus.inst.statusHandle.redraws = 2;
+
+		if (Context.tool == ToolColorId && i == Context.colorIdHandle.position) {
+			UIHeader.inst.headerHandle.redraws = 2;
+			Context.ddirty = 2;
+			Context.colorIdPicked = false;
+			UIToolbar.inst.toolbarHandle.redraws = 1;
+		}
 		Data.deleteImage(asset.file);
 		Project.assetMap.remove(asset.id);
 		Project.assets.splice(i, 1);

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -46,7 +46,11 @@ class UIHeader {
 				ui.text(tr("Color ID Map"));
 				if (Project.assetNames.length > 0) {
 					var cid = ui.combo(Context.colorIdHandle, App.enumTexts("TEX_IMAGE"), tr("Color ID"));
-					if (Context.colorIdHandle.changed) Context.ddirty = 2;
+					if (Context.colorIdHandle.changed) {
+						Context.ddirty = 2;
+						Context.colorIdPicked = false;
+						UIToolbar.inst.toolbarHandle.redraws = 1;
+					}
 					ui.image(Project.getImage(Project.assets[cid]));
 				}
 				if (ui.button(tr("Import"))) {

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -7,7 +7,9 @@ import iron.RenderPath;
 import arm.node.MakeMaterial;
 import arm.util.UVUtil;
 import arm.util.RenderUtil;
+import arm.io.ImportAsset;
 import arm.io.ImportFont;
+import arm.sys.Path;
 import arm.Enums;
 
 class UIHeader {
@@ -42,9 +44,17 @@ class UIHeader {
 					UIToolbar.inst.toolbarHandle.redraws = 1;
 				}
 				ui.text(tr("Color ID Map"));
-				var cid = ui.combo(Context.colorIdHandle, App.enumTexts("TEX_IMAGE"), tr("Color ID"));
-				if (Context.colorIdHandle.changed) Context.ddirty = 2;
-				if (Project.assets.length > 0) ui.image(Project.getImage(Project.assets[cid]));
+				if (Project.assetNames.length > 0) {
+					var cid = ui.combo(Context.colorIdHandle, App.enumTexts("TEX_IMAGE"), tr("Color ID"));
+					if (Context.colorIdHandle.changed) Context.ddirty = 2;
+					ui.image(Project.getImage(Project.assets[cid]));
+				}
+				else if (ui.button(tr("Import"))) {
+					UIFiles.show(Path.textureFormats.join(","), false, true, function(path: String) {
+						ImportAsset.run(path, -1.0, -1.0, true, false);
+						UIStatus.inst.statusHandle.redraws = 2;
+					});
+			}
 			}
 			else if (Context.tool == ToolPicker) {
 				var baseRPicked = Math.round(Context.pickedColor.base.R * 10) / 10;

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -37,7 +37,10 @@ class UIHeader {
 				if (Context.colorIdPicked) {
 					ui.image(RenderPath.active.renderTargets.get("texpaint_colorid").image, 0xffffffff, 64);
 				}
-				if (ui.button(tr("Clear"))) Context.colorIdPicked = false;
+				if (ui.button(tr("Clear"))) {
+					Context.colorIdPicked = false;
+					UIToolbar.inst.toolbarHandle.redraws = 1;
+				}
 				ui.text(tr("Color ID Map"));
 				var cid = ui.combo(Context.colorIdHandle, App.enumTexts("TEX_IMAGE"), tr("Color ID"));
 				if (Context.colorIdHandle.changed) Context.ddirty = 2;

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -49,12 +49,21 @@ class UIHeader {
 					if (Context.colorIdHandle.changed) Context.ddirty = 2;
 					ui.image(Project.getImage(Project.assets[cid]));
 				}
-				else if (ui.button(tr("Import"))) {
+				if (ui.button(tr("Import"))) {
 					UIFiles.show(Path.textureFormats.join(","), false, true, function(path: String) {
 						ImportAsset.run(path, -1.0, -1.0, true, false);
+
+						Context.colorIdHandle.position = Project.assetNames.length - 1;
+						for (a in Project.assets) {
+							// Already imported
+							if (a.file == path) Context.colorIdHandle.position = Project.assets.indexOf(a);
+						}
+						Context.ddirty = 2;
+						Context.colorIdPicked = false;
+						UIToolbar.inst.toolbarHandle.redraws = 1;
 						UIStatus.inst.statusHandle.redraws = 2;
 					});
-			}
+				}
 			}
 			else if (Context.tool == ToolPicker) {
 				var baseRPicked = Math.round(Context.pickedColor.base.R * 10) / 10;

--- a/Sources/arm/ui/UIToolbar.hx
+++ b/Sources/arm/ui/UIToolbar.hx
@@ -3,6 +3,7 @@ package arm.ui;
 import kha.System;
 import zui.Zui;
 import arm.Enums;
+import iron.RenderPath;
 import arm.Translator._tr;
 
 class UIToolbar {
@@ -72,7 +73,11 @@ class UIToolbar {
 					ui._x += 2;
 					if (Context.tool == i) ui.fill(-1, 2, 32 + 2, 32 + 2, ui.t.HIGHLIGHT_COL);
 					var rect = Res.tile50(img, i, 0);
+					var _y = ui._y;
 					if (ui.image(img, iconAccent, null, rect.x, rect.y, rect.w, rect.h) == State.Started) Context.selectTool(i);
+					if (i == 8 && Context.colorIdPicked) {
+							ui.g.drawScaledSubImage(RenderPath.active.renderTargets.get("texpaint_colorid").image, 0, 0, 1, 1, 0, _y + 1.5 * ui.SCALE(), 5 * ui.SCALE(), 34 * ui.SCALE());
+					}
 					if (ui.isHovered) ui.tooltip(tr(toolNames[i]) + " " + keys[i]);
 					ui._x -= 2;
 					ui._y += 2;


### PR DESCRIPTION
This PR improves the color id tool a bit.

1. It fixes a unreported bug. Suppose the color id tool is selected but the user has no imported textures. If the user imports a texture the header and the viewport is not redrawn.
2. @[Wario-Ametrano](https://github.com/Wario-Ametrano) proposed the idea to show the currently picked color in the toolbar in https://github.com/armory3d/armorpaint/issues/1069 . I really like this ideas as it makes the color id tool much easier to use and gives a visual hint that a color id is active. I did not implement his idea to have a context menu for the color id tool to clear the picked color. Imho this would be not only be inconsistent but also a very unusual option to have. While some applications have context menus for their toolbar icon these menus are mostly related to "add to quick bar" or similar commands. My implementation looks like this 
![grafik](https://user-images.githubusercontent.com/28649121/157411482-ca046e7d-4d03-46d6-b3c3-6dcb6ef1ecfb.png) If you don't like the position or shape we can change it. I'm also a bit unsure about my positioning. You might want to take a look at it. I had a hard time to put the bar exactly where I wanted to have it (especially to work on all ui zoom levels). The bar is hard to distinguish from the backgroud if the color id is similar to the background but the same holds for the preview in the header as well and it is somehow unavoidable. Maybe a border would help but that looks ugly. Also color id maps are colorful most of the time so maybe we can leave it as it is....
3. In case there is no texture in the project yet I added an import button to the color id header. 
![grafik](https://user-images.githubusercontent.com/28649121/157412950-c73b1a7a-430b-4f06-93f2-5991f2f24aa4.png)
 I think this is handy. QUESTION: Currently the button is only shown if there is no texture yet. Maybe it would be a good idea to show this button unconditional because: What would a user do to set a color id the first time ? 1. Select the tool. 2. Realize there is no id map yet, go to the Browser or the textures tab to import one. So I propose to add an import button that is there permanently and and sets the newly imported texture as id map. The space is there... What do you think @luboslenco ?
4. QUESTION: I could imagine to have a "set as color id map" entry in the textures tab context menu, too. Might be convenient as well.
5. QUESTION: If the color id tool is open and the currently selected texture is deleted (via textures tab) the viewport is not updated. Leave it or redraw viewport on delete texture if the color id tool is selected?