### PR TITLE
Pbr swatches

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -415,7 +415,10 @@ class App {
 					TabMaterials.acceptSwatchDrag(dragSwatch);
 				}
 				else if (inLayers || inViewport) {
-					Layers.createColorLayer(dragSwatch.base.value);
+					var color = dragSwatch.base;
+					color.A = dragSwatch.opacity;
+
+					Layers.createColorLayer(color.value, dragSwatch.occlusion, dragSwatch.roughness, dragSwatch.metallic);
 				}
 				else if (inSwatches) {
 					TabSwatches.acceptSwatchDrag(dragSwatch);

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -11,7 +11,6 @@ import kha.graphics4.BlendingFactor;
 import kha.graphics4.CompareMode;
 import iron.RenderPath;
 import iron.math.Mat4;
-import arm.ui.UISidebar;
 import arm.ui.UIHeader;
 import arm.data.LayerSlot;
 import arm.node.MakeMaterial;

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -917,13 +917,13 @@ class Layers {
 		Context.layerPreviewDirty = true;
 	}
 
-	public static function createColorLayer(baseColor: Int) {
+	public static function createColorLayer(baseColor: Int, occlusion = 1.0, roughness = Layers.defaultRough, metallic = 0.0 ) {
 		function _init() {
 			var l = newLayer(false);
 			History.newLayer();
 			l.uvType = UVMap;
 			l.objectMask = Context.layerFilter;
-			l.clear(baseColor);
+			l.clear(baseColor, occlusion, roughness, metallic);
 		}
 		iron.App.notifyOnInit(_init);
 	}

--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -584,6 +584,10 @@ class Project {
 		return { base: base, opacity: 1.0, occlusion: 1.0, roughness: 0.0, metallic: 0.0, normal: 0xff8080ff, emission: 0.0, height: 0.0, subsurface: 0.0 };
 	}
 
+	public static function cloneSwatch(swatch: TSwatchColor) : TSwatchColor {
+		return { base: swatch.base, opacity: swatch.opacity, occlusion: swatch.occlusion, roughness: swatch.roughness, metallic: swatch.metallic, normal: swatch.normal, emission: swatch.emission, height: swatch.height, subsurface: swatch.subsurface };
+	}
+
 	public static function setDefaultSwatches() {
 		// 32-Color Palette by Andrew Kensler
 		// http://eastfarthing.com/blog/2016-05-06-palette/

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -165,7 +165,7 @@ class LayerSlot {
 		}
 	}
 
-	public function clear(baseColor = 0x00000000, baseImage: kha.Image = null) {
+	public function clear(baseColor = 0x00000000, baseImage: kha.Image = null, occlusion = 1.0, roughness = Layers.defaultRough, metallic = 0.0) {
 		texpaint.g4.begin();
 		texpaint.g4.clear(baseColor); // Base
 		texpaint.g4.end();
@@ -180,7 +180,7 @@ class LayerSlot {
 			texpaint_nor.g4.clear(kha.Color.fromFloats(0.5, 0.5, 1.0, 0.0)); // Nor
 			texpaint_nor.g4.end();
 			texpaint_pack.g4.begin();
-			texpaint_pack.g4.clear(kha.Color.fromFloats(1.0, Layers.defaultRough, 0.0, 0.0)); // Occ, rough, met
+			texpaint_pack.g4.clear(kha.Color.fromFloats(occlusion, roughness, metallic, 0.0)); // Occ, rough, met
 			texpaint_pack.g4.end();
 		}
 

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -241,6 +241,13 @@ class TabMaterials {
 			if (node.type == "RGB" ) {
 				node.outputs[0].default_value = [swatch.base.R, swatch.base.G, swatch.base.B, swatch.base.A];
 			}
+			else if (node.type == "OUTPUT_MATERIAL_PBR") {
+				node.inputs[1].default_value = swatch.opacity;
+				node.inputs[2].default_value = swatch.occlusion;
+				node.inputs[3].default_value = swatch.roughness;
+				node.inputs[4].default_value = swatch.metallic;
+				node.inputs[7].default_value = swatch.height;
+			}
 		}
 		Project.materials.push(Context.material);
 		updateMaterial();

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -173,7 +173,16 @@ class TabSwatches {
 							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteSwatch(Project.raw.swatches[i]);
 							}
-						}, 2 + add);
+							else if (ui.button(tr("Create Material"), Left)) {
+								TabMaterials.acceptSwatchDrag(Project.raw.swatches[i]);
+							}
+							else if (ui.button(tr("Create Color Layer"), Left)) {
+								var color = Project.raw.swatches[i].base;
+								color.A = Project.raw.swatches[i].opacity;
+			
+								Layers.createColorLayer(color.value, Project.raw.swatches[i].occlusion, Project.raw.swatches[i].roughness, Project.raw.swatches[i].metallic);
+							}
+						}, 4 + add);
 					}
 					if (ui.isHovered) {
 						var val = untyped Project.raw.swatches[i].base;

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -158,12 +158,14 @@ class TabSwatches {
 						UIMenu.draw(function(ui: Zui) {
 							ui.text(tr("Swatch"), Right, ui.t.HIGHLIGHT_COL);
 							if (ui.button(tr("Duplicate"), Left)) {
-								Context.setSwatch(Project.makeSwatch(Context.swatch.base));
+								Context.setSwatch(Project.cloneSwatch(Context.swatch));
 								Project.raw.swatches.push(Context.swatch);
 							}
 							#if (krom_windows || krom_linux || krom_darwin)
-							else if (ui.button(tr("Copy"), Left)) {
-								var val = untyped Context.swatch.base;
+							else if (ui.button(tr("Copy Hex code"), Left)) {
+								var color = Context.swatch.base;
+								color.A = Context.swatch.opacity;
+								var val = untyped color;
 								if (val < 0) val += untyped 4294967296;
 								Krom.copyToClipboard(untyped val.toString(16));
 							}

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -131,9 +131,19 @@ class TabSwatches {
 								var h = Id.handle();
 								h.color = Context.swatch.base;
 								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, 11 * ui.t.ELEMENT_H * ui.SCALE(), true);
+								var hopacity = Id.handle({ value: Context.swatch.opacity });
+								Context.swatch.opacity = ui.slider(hopacity, "Opacity", 0, 1, true);
+								var hocclusion = Id.handle({ value: Context.swatch.occlusion });
+								Context.swatch.occlusion = ui.slider(hocclusion, "Occlusion", 0, 1, true);
+								var hroughness = Id.handle({ value: Context.swatch.roughness });
+								Context.swatch.roughness = ui.slider(hroughness, "Roughness", 0, 1, true);
+								var hmetallic = Id.handle({ value: Context.swatch.metallic });
+								Context.swatch.metallic = ui.slider(hmetallic, "Metallic", 0, 1, true);
+								var hheight = Id.handle({ value: Context.swatch.height });
+								Context.swatch.height = ui.slider(hheight, "Height", 0, 1, true);
 								if (ui.changed || ui.isTyping) UIMenu.keepOpen = true;
 								if (ui.inputReleased) Context.setSwatch(Context.swatch); // Trigger material preview update
-							}, 11, Std.int(Input.getMouse().x - 200 * ui.SCALE()), Std.int(Input.getMouse().y - 250 * ui.SCALE()));
+							}, 16, Std.int(Input.getMouse().x - 200 * ui.SCALE()), Std.int(Input.getMouse().y - 250 * ui.SCALE()));
 						}
 
 						Context.selectTime = Time.time();

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -185,7 +185,9 @@ class TabSwatches {
 						}, 4 + add);
 					}
 					if (ui.isHovered) {
-						var val = untyped Project.raw.swatches[i].base;
+						var color = Project.raw.swatches[i].base;
+						color.A = Project.raw.swatches[i].opacity;
+						var val = untyped color;
 						if (val < 0) val += untyped 4294967296;
 						ui.tooltip("#" + untyped val.toString(16));
 					}

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -95,7 +95,7 @@ class UIHeader {
 					var uiy = ui._y;
 					App.dragOffX = -(mouse.x - uix - ui._windowX - 3);
 					App.dragOffY = -(mouse.y - uiy - ui._windowY + 1);
-					App.dragSwatch = Project.makeSwatch(h.color.value);
+					App.dragSwatch = Project.cloneSwatch(Context.pickedColor);
 				}
 				if (ui.isHovered) ui.tooltip(tr("Drag and drop picked color to swatches, materials, layers or to the node editor."));
 				if (ui.isHovered && ui.inputReleased) {
@@ -107,7 +107,7 @@ class UIHeader {
 					}, 10);
 				}
 				if (ui.button(tr("Add Swatch"))) {
-					var newSwatch = Project.makeSwatch(Context.pickedColor.base);
+					var newSwatch = Project.cloneSwatch(Context.pickedColor);
 					Context.setSwatch(newSwatch);
 					Project.raw.swatches.push(newSwatch);
 					UIStatus.inst.statusHandle.redraws = 1;


### PR DESCRIPTION
I started implementing pbr swatches. 
This PR includes the following features

1. The color picker produces pbr swatches now.
2. The materials tab and the layers tab accept pbr swatches now.
3. The swatches tab has a ui for dealing with pbr swatches now. All commands are pbr swatch ready, too.
4. I added two commands to the context menu: One to create a new material from swatch, one to create a new layer from swatch. These two are not only pretty handy but probably a nice way to show the user what to do with swatches. Suppose the user does not understand the drag and drop feature the swatches become useless. It's also good for the touch versions of ArmorPaint.
5. Consistency with the old non-pbr swatch implementation: Because the other channels get default values there is no change in behavior if the user creates a new swatch and drops it in the layers or materials tab.

Similar to #1318 I have the problem with Layers.hx. The thing is that Layers.hx has "\r\n" line endings in the repository. If I push changes containing new lines everything gets converted to "\n" line endings and thus the whole file changes. What should we do? Maybe you could normalize the file/the whole repo before merging? Maybe this solves the issue automatically but I'm not sure though...

What is not polished/perfect yet?
1. The swatch previews themselves are still represented by the base color. One might want to change it but I don't know how this could be done. I think a combination of layer icons (the checker pattern to indicate transparency) and the material icons would be perfect.
2. The tooltip doesn't feel polished to me anymore. Is it still a good idea to show the hex code? The swatches tab should also contain some tooltip to tell the user about the drag and drop feature.
3. Swatches have to "alpha" values. One in base one in opacity. You can see the ugly effects at some places. This is also a feature problem because the colorWheel does not support the transparency in the hex edit widget in the third tab. Maybe it would also be a good idea to turn on the color wheel's transparency feature.
4. The context menu entries in ArmorPaint should get some systematicity in their order to be consistent. This is a more general task of course.
5. Dropping a swatch to nodes produces a rgb node. I'm unsure whether it would be better to drop a "swatch"-node or something similar in order to expose the full swatch features. Maybe it is not needed because dropping to materials tab does so.
6. I could also imagine a feature to support swatch names, i.e. a string could get attached to a swatch. It is supported by some applications like GIMP, ... Unsure whether we need this
7. I would like to add an importer for gimp palettes (gpl file, simple text file that lists the colors). Currently it is not so convenient to move existing palettes to ArmorPaint. Maybe we could also make an exporter for gpl files in order to be compatible with other programs, too.