### PR TITLE
Tooltip improvements

### DIFF
--- a/Sources/arm/ui/TabBrushes.hx
+++ b/Sources/arm/ui/TabBrushes.hx
@@ -102,7 +102,7 @@ class TabBrushes {
 								iron.App.notifyOnInit(_init);
 							}
 
-							if (Project.brushes.length > 1 && ui.button(tr("Delete"), Left)) {
+							if (Project.brushes.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteBrush(Project.brushes[i]);
 							}
 						}, 3 + add);

--- a/Sources/arm/ui/TabFonts.hx
+++ b/Sources/arm/ui/TabFonts.hx
@@ -98,7 +98,7 @@ class TabFonts {
 						UIMenu.draw(function(ui: Zui) {
 							ui.text(fontName, Right, ui.t.HIGHLIGHT_COL);
 
-							if (Project.fonts.length > 1 && ui.button(tr("Delete"), Left) && Project.fonts[i].file != "") {
+							if (Project.fonts.length > 1 && ui.button(tr("Delete"), Left, "delete") && Project.fonts[i].file != "") {
 								deleteFont(Project.fonts[i]);
 							}
 						}, 1 + add);

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -543,7 +543,7 @@ class TabLayers {
 			}
 
 			ui.enabled = canDelete(l);
-			if (ui.button(tr("Delete"), Left)) {
+			if (ui.button(tr("Delete"), Left, "delete")) {
 				deleteLayer(l);
 			}
 			ui.enabled = true;

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -139,7 +139,7 @@ class TabMaterials {
 								iron.App.notifyOnInit(_init);
 							}
 
-							if (Project.materials.length > 1 && ui.button(tr("Delete"), Left)) {
+							if (Project.materials.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteMaterial(m);
 							}
 

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -158,7 +158,7 @@ class TabSwatches {
 								Krom.copyToClipboard(untyped val.toString(16));
 							}
 							#end
-							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left)) {
+							else if (Project.raw.swatches.length > 1 && ui.button(tr("Delete"), Left, "delete")) {
 								deleteSwatch(Project.raw.swatches[i]);
 							}
 						}, 2 + add);

--- a/Sources/arm/ui/TabTextures.hx
+++ b/Sources/arm/ui/TabTextures.hx
@@ -146,7 +146,7 @@ class TabTextures {
 										Context.ddirty = 2;
 									}
 								}
-								if (ui.button(tr("Delete"), Left)) {
+								if (ui.button(tr("Delete"), Left, "delete")) {
 									deleteTexture(asset);
 								}
 								if (!isPacked && ui.button(tr("Open Containing Directory..."), Left)) {

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -141,6 +141,7 @@ class UIMenu {
 				}
 				menuAlign(ui);
 				Context.envmapAngle = ui.slider(envaHandle, tr("Environment Angle"), 0.0, 360.0, true, 1) / 180.0 * Math.PI;
+				if (ui.isHovered) ui.tooltip(tr("{shortcut} and move mouse", ["shortcut" => Config.keymap.rotate_envmap]));
 				if (envaHandle.changed) Context.ddirty = 2;
 
 				if (Scene.active.lights.length > 0) {
@@ -161,6 +162,7 @@ class UIMenu {
 					lahandle.value = Context.lightAngle / Math.PI * 180;
 					menuAlign(ui);
 					var newAngle = ui.slider(lahandle, tr("Light Angle"), 0.0, 360.0, true, 1) / 180 * Math.PI;
+					if (ui.isHovered) ui.tooltip(tr("{shortcut} and move mouse", ["shortcut" => Config.keymap.rotate_light]));
 					var ldiff = newAngle - Context.lightAngle;
 					if (Math.abs(ldiff) > 0.005) {
 						if (newAngle < 0) newAngle += (Std.int(-newAngle / (2 * Math.PI)) + 1) * 2 * Math.PI;

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -353,7 +353,14 @@ class UIMenu {
 				menuFill(ui);
 				menuAlign(ui);
 				Context.cameraControls = Ext.inlineRadio(ui, Id.handle({ position: Context.cameraControls }), [tr("Orbit"), tr("Rotate"), tr("Fly")], Left);
+				var orbitAndRotateTooltip = tr("Orbit and Rotate mode:\n{rotate_shortcut} or move right mouse button to rotate.\n{zoom_shortcut} or scroll to zoom.\n{pan_shortcut} or move middle mouse to pan.", 
+				["rotate_shortcut" => Config.keymap.action_rotate, 
+				"zoom_shortcut" => Config.keymap.action_zoom,  
+				"pan_shortcut" => Config.keymap.action_pan,
+				]);
 
+				var flyTooltip = tr("Fly mode:\nHold the right mouse button and one of the following commands:\nmove mouse to rotate.\nw, up or scroll up to move forward.\ns, down or scroll down to move backward.\na or left to move left.\nd or right to move right.\ne to move up.\nq to move down.\nHold shift to move faster or alt to move slower.");
+				if (ui.isHovered) ui.tooltip(orbitAndRotateTooltip + "\n\n" + flyTooltip);
 				menuFill(ui);
 				menuAlign(ui);
 				Context.cameraType = Ext.inlineRadio(ui, Context.camHandle, [tr("Perspective"), tr("Orthographic")], Left);


### PR DESCRIPTION
Remade the pull request #1313 because there were already more merge commits than actual commits.

1. Added the delete shortcuts to the context menus. They were missing and I think it is better to be explicit about features.
2. Added the shortcuts for light angle and env angle as tooltip.
3. Added an explanation for using the different camera modes. The tooltip is a bit long, that's why I split the string into two. It should also simplify translation. Nonetheless the tooltip is great imho as it explains the usage in a compact and comprehensible way. If someone does not know the shortcuts or wants to look them up it's very easy to do now. Also the fly mode is only explained in code but nowhere in ui. That should not happen.