### PR TITLE
Color picker support for color wheels

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -458,6 +458,9 @@ class App {
 			Krom.setMouseCursor(0); // Arrow
 			isDragging = false;
 		}
+		if (Context.colorPickerCallback != null && mouse.released()) {
+			Context.colorPickerCallback = null;
+		}
 
 		handleDropPaths();
 

--- a/Sources/arm/Context.hx
+++ b/Sources/arm/Context.hx
@@ -65,6 +65,7 @@ class Context {
 
 	public static var swatch: TSwatchColor;
 	public static var pickedColor: TSwatchColor = Project.makeSwatch();
+	public static var colorPickerCallback: TSwatchColor->Void = null;
 	public static var materialIdPicked = 0;
 	public static var uvxPicked = 0.0;
 	public static var uvyPicked = 0.0;

--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -271,6 +271,7 @@ class Project {
 			Project.setDefaultSwatches();
 			Context.swatch = Project.raw.swatches[0];
 			Context.pickedColor = Project.makeSwatch();
+			Context.colorPickerCallback = null;
 			History.reset();
 
 			MakeMaterial.parsePaintMaterial();

--- a/Sources/arm/render/RenderPathPaint.hx
+++ b/Sources/arm/render/RenderPathPaint.hx
@@ -211,6 +211,11 @@ class RenderPathPaint {
 					var c = texpaint_pack_picker.getPixels();
 					var d = texpaint_uv_picker.getPixels();
 
+					if (Context.colorPickerCallback != null) {
+						Context.pickerSelectMaterial = false; // The selected material should not change while picking.
+						Context.colorPickerCallback(Context.pickedColor);
+					}
+
 					// Picked surface values
 					#if (kha_metal || kha_vulkan)
 					Context.pickedColor.base.Rb = a.get(2);

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -130,7 +130,13 @@ class TabSwatches {
 								ui.changed = false;
 								var h = Id.handle();
 								h.color = Context.swatch.base;
-								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, 11 * ui.t.ELEMENT_H * ui.SCALE(), true);
+								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, 11 * ui.t.ELEMENT_H * ui.SCALE(), true, function () {
+									Context.selectTool(ToolPicker);
+									Context.pickerSelectMaterial = false;
+									Context.colorPickerCallback = function (color: TSwatchColor) {
+										Project.raw.swatches[i].base = color.base;
+									};
+								});
 								if (ui.changed || ui.isTyping) UIMenu.keepOpen = true;
 								if (ui.inputReleased) Context.setSwatch(Context.swatch); // Trigger material preview update
 							}, 11, Std.int(Input.getMouse().x - 200 * ui.SCALE()), Std.int(Input.getMouse().y - 250 * ui.SCALE()));

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -682,6 +682,17 @@ class UINodes {
 				Zui.isCopy = Zui.isCut = Zui.isPaste = ui.isDeleteDown = false;
 			}
 
+			if (nodes.colorPickerCallback != null) {
+				Context.selectTool(ToolPicker);
+				var tmp = nodes.colorPickerCallback;
+				Context.colorPickerCallback = function(color : TSwatchColor) { 
+					tmp(color.base);
+					UINodes.inst.hwnd.redraws = 2;
+					UINodes.inst.canvasChanged();
+				};
+				nodes.colorPickerCallback = null;
+			}
+
 			// Remove nodes with unknown id for this canvas type
 			if (Zui.isPaste) {
 				var nodeList = canvasType == CanvasMaterial ? NodesMaterial.list : NodesBrush.list;


### PR DESCRIPTION
We already discussed the idea to give the color wheel color picker support. 
How did I do it?

- I realized to color picker might not be open anymore when the picker is used (similar to Blender's behavior). That's why the implementation has to modify the variables directly and not the color wheel handle.
- The behavior depends slightly on the place the color picker is used. E.g. a changed RGB-node should recompile the material if live materials are enabled, a swatch should get updated, ...
- The picker is highly dependent on ArmorPaint but zui (the color wheel and nodes canvas) should not get a dependency on ArmorPaint.
- Thus I added a callback to the colorWheel. Whenever the picker button is clicked this code is executed to take the place dependent things. It typically will switch the currently used tool to `ToolPicker` and sets yet another callback that gets called whenever the picker changes. This second callback does the actual color modification.
- Releasing the mouse ends the picking process.

How does it look like?
![grafik](https://user-images.githubusercontent.com/28649121/158023527-d0cff214-b3f6-4fc4-899c-2f3c1757a8b9.png) ![grafik](https://user-images.githubusercontent.com/28649121/158023538-5b516565-0c87-4503-ac78-f88c3025a6c4.png) ![grafik](https://user-images.githubusercontent.com/28649121/158023551-5eb64832-324c-4005-9f97-d6d69fc7d107.png)


What has to be done yet
1. Currently the button is a 'P'. It should become the picker image. That's a little bit of a problem because the current mechanisms to make images available in zui is not so straight forward. I had the feeling that my addition of the value picker was already ugly. That's why I'd like to discuss that.
2. The button could use a context specific tooltip. That's again a small problem.
3. The mouse cursor could get a picker next to it similar to attached swatches, materials and images while drag and drop. I believe this would make the behavior more intuitive. I have not done it because I failed to completely turn off the `pickerSelectMaterial` function. The white material "ball" is still attached to the mouse. Steps to reproduce: 1. select ToolPicker manually. 2. Now use the picker in the swatches color wheel or the nodes color wheel.

Maybe we should change my initial implementation. I could also imagine to remove the picker from the color wheel completely. This would simplify situations like TabSwatches a lot and give us more control over the picker. The picker's position could stay the same though. For nodes the situation would simplify, too and we could put the picker here:
![grafik](https://user-images.githubusercontent.com/28649121/158023397-d082e6a6-847b-4795-9168-9a8f31abaaad.png) 
The problem to give zui access to the "picker" icon remains though.

