### PR TITLE
Fix #1330

### DIFF
--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -791,11 +791,13 @@ class Layers {
 			Context.pdirty = 0;
 			Context.ddirty = 2;
 			Context.rdirty = 2;
+			Context.layersPreviewDirty = true; // Repaint all layer previews as multiple layers might have changed.
 			if (current != null) current.begin(false);
 			Context.layer = _layer;
 			setObjectMask();
 			Context.tool = _tool;
 			Context.fillTypeHandle.position = _fillType;
+			MakeMaterial.parsePaintMaterial(false);
 		}
 	}
 


### PR DESCRIPTION
Took a quick look at https://github.com/armory3d/armorpaint/issues/1330 because it looked interesting to me and tried to fix it. Might not be perfect and is definitely not the most efficient solution but could serve as a starter for you. Feel free to close it if you found a better way to fix it.

Currently we have to recreate all layer previews because there is no way to recreate multiple previews. In the future we might want to rewrite the layer preview dirty mechanism. I understand that we can not create it inplace because the layer might not be redrawn yet.