### PR TITLE
Improve swatches and picker

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -463,6 +463,7 @@ class App {
 		}
 		if (Context.colorPickerCallback != null && (mouse.released() || mouse.released("right"))) {
 			Context.colorPickerCallback = null;
+			Context.selectTool(Context.colorPickerPreviousTool);
 		}
 
 		handleDropPaths();

--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -461,7 +461,7 @@ class App {
 			Krom.setMouseCursor(0); // Arrow
 			isDragging = false;
 		}
-		if (Context.colorPickerCallback != null && mouse.released()) {
+		if (Context.colorPickerCallback != null && (mouse.released() || mouse.released("right"))) {
 			Context.colorPickerCallback = null;
 		}
 

--- a/Sources/arm/Context.hx
+++ b/Sources/arm/Context.hx
@@ -66,6 +66,7 @@ class Context {
 	public static var swatch: TSwatchColor;
 	public static var pickedColor: TSwatchColor = Project.makeSwatch();
 	public static var colorPickerCallback: TSwatchColor->Void = null;
+	public static var colorPickerPreviousTool = ToolBrush;
 	public static var materialIdPicked = 0;
 	public static var uvxPicked = 0.0;
 	public static var uvyPicked = 0.0;

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -134,7 +134,7 @@ class TabSwatches {
 								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, 11 * ui.t.ELEMENT_H * ui.SCALE(), true, function () {
 									Context.selectTool(ToolPicker);
 									Context.colorPickerCallback = function (color: TSwatchColor) {
-										Project.raw.swatches[i].base = color.base;
+										Project.raw.swatches[i] = Project.cloneSwatch(color);
 									};
 								});
 								var hopacity = Id.handle();

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -132,6 +132,7 @@ class TabSwatches {
 								h.color = Context.swatch.base;
 
 								Context.swatch.base = zui.Ext.colorWheel(ui, h, false, null, 11 * ui.t.ELEMENT_H * ui.SCALE(), true, function () {
+									Context.colorPickerPreviousTool = Context.tool;
 									Context.selectTool(ToolPicker);
 									Context.colorPickerCallback = function (color: TSwatchColor) {
 										Project.raw.swatches[i] = Project.cloneSwatch(color);

--- a/Sources/arm/ui/TabSwatches.hx
+++ b/Sources/arm/ui/TabSwatches.hx
@@ -137,15 +137,20 @@ class TabSwatches {
 										Project.raw.swatches[i].base = color.base;
 									};
 								});
-								var hopacity = Id.handle({ value: Context.swatch.opacity });
+								var hopacity = Id.handle();
+								hopacity.value = Context.swatch.opacity;
 								Context.swatch.opacity = ui.slider(hopacity, "Opacity", 0, 1, true);
-								var hocclusion = Id.handle({ value: Context.swatch.occlusion });
+								var hocclusion = Id.handle();
+								hocclusion.value = Context.swatch.occlusion;
 								Context.swatch.occlusion = ui.slider(hocclusion, "Occlusion", 0, 1, true);
-								var hroughness = Id.handle({ value: Context.swatch.roughness });
+								var hroughness = Id.handle();
+								hroughness.value = Context.swatch.roughness;
 								Context.swatch.roughness = ui.slider(hroughness, "Roughness", 0, 1, true);
-								var hmetallic = Id.handle({ value: Context.swatch.metallic });
+								var hmetallic = Id.handle();
+								hmetallic.value = Context.swatch.metallic;
 								Context.swatch.metallic = ui.slider(hmetallic, "Metallic", 0, 1, true);
-								var hheight = Id.handle({ value: Context.swatch.height });
+								var hheight = Id.handle();
+								hheight.value = Context.swatch.height;
 								Context.swatch.height = ui.slider(hheight, "Height", 0, 1, true);
 
 								if (ui.changed || ui.isTyping) UIMenu.keepOpen = true;

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -683,6 +683,7 @@ class UINodes {
 			}
 
 			if (nodes.colorPickerCallback != null) {
+				Context.colorPickerPreviousTool = Context.tool;
 				Context.selectTool(ToolPicker);
 				var tmp = nodes.colorPickerCallback;
 				Context.colorPickerCallback = function(color: TSwatchColor) {

--- a/Sources/arm/ui/UISidebar.hx
+++ b/Sources/arm/ui/UISidebar.hx
@@ -815,13 +815,19 @@ class UISidebar {
 			}
 
 			// Show picked material next to cursor
-			if (Context.tool == ToolPicker && Context.pickerSelectMaterial) {
+			if (Context.tool == ToolPicker && Context.pickerSelectMaterial && Context.colorPickerCallback == null) {
 				var img = Context.material.imageIcon;
 				#if kha_opengl
 				g.drawScaledImage(img, mx + 10, my + 10 + img.height, img.width, -img.height);
 				#else
 				g.drawImage(img, mx + 10, my + 10);
 				#end
+			}
+			if (Context.tool == ToolPicker && Context.colorPickerCallback != null) {
+				var img = Res.get("icons.k");
+				var rect = Res.tile50(img, ToolPicker, 0);
+					
+				g.drawSubImage(img, mx + 10, my + 10, rect.x, rect.y, rect.w, rect.h);
 			}
 
 			var cursorImg = Res.get("cursor.k");


### PR DESCRIPTION
Improved the swatches and the picker a bit

- Now the picker for swatches supports pbr swatches
- For some reason I do not understand why I didn't see it my pbr swatch ui did not work
- Made the picker more intuitive: now there is a picker icon next to the mouse, picking can be cancelled by right click and the tool is switched back to the previous one. 
I think it is way more intuitive now

QUESTION: Tried Alpha instead of opacity
![grafik](https://user-images.githubusercontent.com/28649121/158646123-b969e822-45e3-446e-ba61-d2cbcc286ddc.png)
Idea is good imho but inconsistent. Either one would change opacity to alpha in all color related situations or we keep it like it is now. My proposal: keep it the way it is because opacity does also influence other channels and not only RGB.