### PR TITLE
Add gimp color palette exporter

### DIFF
--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -32,6 +32,7 @@ import arm.io.ImportBlend;
 import arm.io.ImportMesh;
 import arm.io.ImportTexture;
 import arm.io.ExportArm;
+import arm.io.ExportGpl;
 import arm.node.NodesBrush;
 import arm.Viewport;
 import arm.ProjectFormat;
@@ -574,10 +575,11 @@ class Project {
 	}
 
 	public static function exportSwatches() {
-		UIFiles.show("arm", true, false, function(path: String) {
+		UIFiles.show("arm,gpl", true, false, function(path: String) {
 			var f = UIFiles.filename;
 			if (f == "") f = tr("untitled");
-			ExportArm.runSwatches(path + Path.sep + f);
+			if (f.endsWith(".gpl")) ExportGpl.run(path + Path.sep + f, f.substring(0,f.lastIndexOf(".")), Project.raw.swatches);
+			else ExportArm.runSwatches(path + Path.sep + f);
 		});
 	}
 

--- a/Sources/arm/io/ExportGpl.hx
+++ b/Sources/arm/io/ExportGpl.hx
@@ -1,0 +1,22 @@
+package arm.io;
+
+import haxe.io.BytesOutput;
+import arm.ProjectFormat;
+
+class ExportGpl {
+
+	public static function run(path: String, name: String, swatches: Array<TSwatchColor>) {
+		var o = new BytesOutput();
+		o.bigEndian = false;
+		o.writeString("GIMP Palette\n");
+		o.writeString("Name: " + name + "\n");
+		o.writeString("# armorpaint.org\n");
+		o.writeString("#\n");
+
+		for (swatch in swatches) {
+			o.writeString(Std.string(swatch.base.Rb) + " " + Std.string(swatch.base.Gb) + " " + Std.string(swatch.base.Bb) + "\n");
+		}
+
+		Krom.fileSaveBytes(path, o.getBytes().getData(), o.getBytes().length);
+	}
+}


### PR DESCRIPTION
Implemented a gimp color palette exporter (gpl files). I think it is useful to be able to share the palette with other programs. Wrote the exporter first in order to get used to the (honestly simple) format. There are two types of gpl file, older ones and newer ones. This exporter uses the newer one. Will implement the importer the next days.