### PR TITLE
Connect to best matching socket on link drag

### DIFF
--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -93,7 +93,16 @@ class UINodes {
 					var n = nodes.nodesSelected[0];
 					if (linkDrag.to_id == -1 && n.inputs.length > 0) {
 						linkDrag.to_id = n.id;
+						var fromType = node.outputs[linkDrag.from_socket].type;
+						// 1. step: Connect to the first socket.
 						linkDrag.to_socket = 0;
+						// 2. step: Try to find the first type-matching socket and use it if present.
+						for (socket in n.inputs) {
+							if (socket.type == fromType) {
+								linkDrag.to_socket = n.inputs.indexOf(socket);
+								break;
+							}
+						}
 						getCanvas(true).links.push(linkDrag);
 					}
 					else if (linkDrag.from_id == -1 && n.outputs.length > 0) {


### PR DESCRIPTION
Currently ArmorPaint always connects to the first socket if the user drags an edge, releases the mouse and creates a new node. Imho ArmorPaint could be a bit smarter and connect to the first matching socket if possible.
Example:
The correct socket is chosen now (at least for the typical situations)
![grafik](https://user-images.githubusercontent.com/28649121/161043879-af0a87a6-2b2d-4b57-a40b-b26e939db468.png)
![grafik](https://user-images.githubusercontent.com/28649121/161044164-ea9225d2-94b3-448c-b94a-20f1418e0b5a.png)


