### PR TITLE
Import gpl

### DIFF
--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -28,6 +28,7 @@ import arm.data.MaterialSlot;
 import arm.node.MakeMaterial;
 import arm.io.ImportAsset;
 import arm.io.ImportArm;
+import arm.io.ImportGpl;
 import arm.io.ImportBlend;
 import arm.io.ImportMesh;
 import arm.io.ImportTexture;
@@ -498,8 +499,9 @@ class Project {
 	}
 
 	public static function importSwatches(replaceExisting = false) {
-		UIFiles.show("arm", false, false, function(path: String) {
-			ImportArm.runSwatches(path, replaceExisting);
+		UIFiles.show("arm,gpl", false, false, function(path: String) {
+			if (Path.isGimpColorPalette(path)) ImportGpl.run(path, replaceExisting);
+			else ImportArm.runSwatches(path, replaceExisting);
 		});
 	}
 

--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -580,7 +580,7 @@ class Project {
 		UIFiles.show("arm,gpl", true, false, function(path: String) {
 			var f = UIFiles.filename;
 			if (f == "") f = tr("untitled");
-			if (f.endsWith(".gpl")) ExportGpl.run(path + Path.sep + f, f.substring(0, f.lastIndexOf(".")), Project.raw.swatches);
+			if (Path.isGimpColorPalette(f)) ExportGpl.run(path + Path.sep + f, f.substring(0, f.lastIndexOf(".")), Project.raw.swatches);
 			else ExportArm.runSwatches(path + Path.sep + f);
 		});
 	}

--- a/Sources/arm/io/ImportAsset.hx
+++ b/Sources/arm/io/ImportAsset.hx
@@ -57,6 +57,9 @@ class ImportAsset {
 		else if (Path.isFolder(path)) {
 			ImportFolder.run(path);
 		}
+		else if (Path.isGimpColorPalette(path)) {
+			ImportGpl.run(path, false);
+		}
 		else {
 			if (Context.enableImportPlugin(path)) {
 				run(path, dropX, dropY, showBox);

--- a/Sources/arm/io/ImportGpl.hx
+++ b/Sources/arm/io/ImportGpl.hx
@@ -1,0 +1,53 @@
+package arm.io;
+
+import kha.Color;
+import haxe.io.BytesInput;
+import kha.Blob;
+import iron.data.Data;
+
+class ImportGpl {
+
+	public static function run(path: String, replaceExisting: Bool) {
+		Data.getBlob(path, function(b: Blob) {
+		var swatches = [];
+		try {
+			var input = new BytesInput(b.bytes);
+			// GIMP's color palette importer: https://gitlab.gnome.org/GNOME/gimp/-/blob/gimp-2-10/app/core/gimppalette-load.c#L39 
+			if (!input.readLine().startsWith("GIMP Palette")) {
+				Console.error(tr("Not a valid GIMP color palette"));
+				return;
+			}
+
+			var delimiter = ~/\s+/ig;
+			while (true) {
+				var line = input.readLine();
+				if (line.startsWith("Name:")) continue;
+				else if (line.startsWith("Columns:")) continue;
+				else if (line.startsWith("#")) continue;
+				else {
+					var tokens = delimiter.split(line);
+					if (tokens.length < 3) continue;
+					var swatch = Project.makeSwatch(Color.fromBytes(Std.parseInt(tokens[0]), Std.parseInt(tokens[1]), Std.parseInt(tokens[2])));
+					swatches.push(swatch);
+				}
+			}
+		}
+		catch (e: haxe.io.Eof) {
+			// Is thrown if end of file is reached.
+		}
+		if (replaceExisting) {
+			Project.raw.swatches = [];
+
+			if (swatches.length == 0) { // No swatches contained
+				Project.raw.swatches.push(Project.makeSwatch());
+			}
+		}
+
+		if (swatches.length > 0) {
+			for (s in swatches) {
+				Project.raw.swatches.push(s);
+			}
+		}
+	});
+	}
+}

--- a/Sources/arm/ui/UIMenu.hx
+++ b/Sources/arm/ui/UIMenu.hx
@@ -72,7 +72,7 @@ class UIMenu {
 				if (menuButton(ui, tr("Import Font..."))) Project.importAsset("ttf,ttc,otf");
 				if (menuButton(ui, tr("Import Material..."))) Project.importMaterial();
 				if (menuButton(ui, tr("Import Brush..."))) Project.importBrush();
-				if (menuButton(ui, tr("Import Swatches..."))) Project.importAsset("arm");
+				if (menuButton(ui, tr("Import Swatches..."))) Project.importSwatches();
 				if (menuButton(ui, tr("Import Mesh..."))) Project.importMesh();
 				if (menuButton(ui, tr("Reimport Mesh"), Config.keymap.file_reimport_mesh)) Project.reimportMesh();
 				if (menuButton(ui, tr("Reimport Textures"), Config.keymap.file_reimport_textures)) Project.reimportTextures();


### PR DESCRIPTION
Implemented a gpl file importer. Implemented it after GIMP's original code https://gitlab.gnome.org/GNOME/gimp/-/blob/gimp-2-10/app/core/gimppalette-load.c#L39
Example:
![grafik](https://user-images.githubusercontent.com/28649121/161286441-c1753ab9-fa0f-415d-b50c-46ba075a2375.png)

What did I change?
- Import gpl files via TabSwatches -> Import
- Import via File -> Import Swatches
- Import via drag and drop
- Improved gpl export a bit, i.e. use the newly added isGimpColorPalette(). Benefit: is case insensitive
