### PR TITLE
Delete material groups

### DIFF
--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -1,5 +1,6 @@
 package arm;
 
+import arm.Project.TNodeGroup;
 import zui.Nodes;
 import arm.ui.UISidebar;
 import arm.ui.UIView2D;
@@ -186,6 +187,10 @@ class History {
 			else if (step.name == tr("Edit Nodes")) {
 				swapCanvas(step);
 			}
+			else if (step.name == tr("Delete Node Group")) {
+				Project.materialGroups.insert(step.canvas_group,{ canvas: null, nodes: new Nodes() });
+				swapCanvas(step);
+			}
 			else if (step.name == tr("New Material")) {
 				Context.material = Project.materials[step.material];
 				step.canvas = Context.material.canvas;
@@ -358,6 +363,10 @@ class History {
 			}
 			else if (step.name == tr("Edit Nodes")) {
 				swapCanvas(step);
+			}
+			else if (step.name == tr("Delete Node Group")) {
+				swapCanvas(step);
+				Project.materialGroups.remove(Project.materialGroups[step.canvas_group]);
 			}
 			else if (step.name == tr("New Material")) {
 				Context.material = new MaterialSlot(Project.materials[0].data);
@@ -538,6 +547,13 @@ class History {
 		step.canvas_type = canvas_type;
 		step.canvas_group = canvas_group;
 		step.canvas = haxe.Json.parse(haxe.Json.stringify(canvas));
+	}
+
+	public static function deleteMaterialGroup(group: TNodeGroup) {
+		var step = push(tr("Delete Node Group"));
+		step.canvas_type = CanvasMaterial;
+		step.canvas_group = Project.materialGroups.indexOf(group);
+		step.canvas = haxe.Json.parse(haxe.Json.stringify(group.canvas));
 	}
 
 	static function push(name: String): TStep {

--- a/Sources/arm/Project.hx
+++ b/Sources/arm/Project.hx
@@ -605,6 +605,20 @@ class Project {
 		for (g in materialGroups) if (g.canvas.name == groupName) return g;
 		return null;
 	}
+
+	public static function isMaterialGroupInUse(group: TNodeGroup) {
+		var canvases: Array<TNodeCanvas> = [];
+		for (m in materials) canvases.push(m.canvas);
+		for (m in materialGroups) canvases.push(m.canvas);
+		for (canvas in canvases) {
+			for (n in canvas.nodes) {
+				if (n.type == "GROUP" && n.name == group.canvas.name) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 }
 
 typedef TNodeGroup = {

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -328,28 +328,6 @@ class UINodes {
 	}
 
 	public static function onNodeRemove(node: TNode) {
-		if (node.type == "GROUP") { // Remove unused groups
-			var found = false;
-			var canvases: Array<TNodeCanvas> = [];
-			for (m in Project.materials) canvases.push(m.canvas);
-			for (m in Project.materialGroups) canvases.push(m.canvas);
-			for (canvas in canvases) {
-				for (n in canvas.nodes) {
-					if (n.type == "GROUP" && n.name == node.name) {
-						found = true;
-						break;
-					}
-				}
-			}
-			if (!found) {
-				for (g in Project.materialGroups) {
-					if (g.canvas.name == node.name) {
-						Project.materialGroups.remove(g);
-						break;
-					}
-				}
-			}
-		}
 	}
 
 	function onCanvasControl(): zui.Nodes.CanvasControl {
@@ -931,7 +909,9 @@ class UINodes {
 			if (isGroupCategory) {
 				for (g in Project.materialGroups) {
 					ui.fill(0, 1, ui._w / ui.SCALE(), ui.t.BUTTON_H + 2, ui.t.ACCENT_SELECT_COL);
+					ui.fill(1, 1, ui._w / ui.SCALE() - 2, ui.t.BUTTON_H + 1 , ui.t.SEPARATOR_COL);
 					ui.enabled = canPlaceGroup(g.canvas.name);
+					ui.row([5 / 6, 1 / 6]);
 					if (ui.button("      " + g.canvas.name, Left)) {
 						pushUndo();
 						var canvas = getCanvas(true);
@@ -941,6 +921,11 @@ class UINodes {
 						nodes.nodesSelected = [node];
 						nodes.nodesDrag = true;
 					}
+					ui.enabled = !Project.isMaterialGroupInUse(g);
+					if (ui.button("x", Center)) {
+						Project.materialGroups.remove(g);
+					}
+					
 					ui.enabled = true;
 				}
 			}

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -665,9 +665,6 @@ class UINodes {
 			ui.windowBorderBottom = Config.raw.layout[LayoutStatusH];
 			nodes.nodeCanvas(ui, c);
 			ui.inputEnabled = _inputEnabled;
-			if (isNodeMenuOperation) {
-				Zui.isCopy = Zui.isCut = Zui.isPaste = ui.isDeleteDown = false;
-			}
 
 			if (nodes.colorPickerCallback != null) {
 				Context.colorPickerPreviousTool = Context.tool;
@@ -710,6 +707,10 @@ class UINodes {
 						i--;
 					}
 				}
+			}
+
+			if (isNodeMenuOperation) {
+				Zui.isCopy = Zui.isCut = Zui.isPaste = ui.isDeleteDown = false;
 			}
 
 			// Recompile material on change

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -924,6 +924,7 @@ class UINodes {
 					}
 					ui.enabled = !Project.isMaterialGroupInUse(g);
 					if (ui.button("x", Center)) {
+						History.deleteMaterialGroup(g);
 						Project.materialGroups.remove(g);
 					}
 					


### PR DESCRIPTION
Currently material groups have the property to get auto deleted once they are not used anymore.
This leads to unwanted behavior:
- Build a meaningful group.
- Remove the material the group is used in.
- Try to reuse it in a newly created material. -> the group is gone and there is no way to restore it.

Other scenarios where this happens are https://github.com/armory3d/armorpaint/issues/1209 and https://github.com/armory3d/armorpaint/issues/1214. Basically they cut the last appearance of a group, it gets deleted and once the user wants to paste it, there is a problem. Both get fixed by this PR.

What did I change?

1. Removed the auto remove feature.
2. Added an option to remove unused groups. 
![grafik](https://user-images.githubusercontent.com/28649121/164705020-aa93af06-32b7-4416-9728-4c2ffa751980.png)
3. Added undo-redo for the operation. This prevents two problems: 
3.1 If a group node is deleted, then the group is deleted and the user clicks undo, the group is restored. Otherwise the group would be still missing and ArmorPaint would freeze.
3.2 If the user deletes the group unintentionally it can be undone. My idea was that this avoids a confirm dialog.

Imho it is easy and intuitive to use.

Further more it was possible to paste unwanted nodes to the canvas by the context menu because the filtering was not applied here. Rearanged the code in order to filter in this case, too.
