### PR TITLE
Select shortcuts

### DIFF
--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -292,6 +292,19 @@ class TabLayers {
 
 			state = ui.image(icon, 0xffffffff, iconH);
 
+			var isTyping = ui.isTyping || UIView2D.inst.ui.isTyping || UINodes.inst.ui.isTyping;
+			if (!isTyping) {
+				if (i < 9 && Operator.shortcut(Config.keymap.select_layer, ShortcutDown)) {
+					var number = Std.string(i + 1) ;
+					var width = ui.ops.font.width(ui.fontSize, number) + 10;
+					var height = ui.ops.font.height(ui.fontSize);
+					ui.g.color = ui.t.TEXT_COL;
+					ui.g.fillRect(uix, uiy, width, height);
+					ui.g.color = ui.t.ACCENT_COL;
+					ui.g.drawString(number, uix + 5, uiy);
+				}
+			}
+
 			if (l.fill_layer == null && l.isMask()) {
 				ui.g.pipeline = null;
 			}

--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -84,6 +84,19 @@ class TabMaterials {
 					var uiy = ui._y;
 					var tile = ui.SCALE() > 1 ? 100 : 50;
 					var state = Project.materials[i].previewReady ? ui.image(img) : ui.image(Res.get("icons.k"), -1, null, tile, tile, tile, tile);
+					var isTyping = ui.isTyping || UIView2D.inst.ui.isTyping || UINodes.inst.ui.isTyping;
+					if (!isTyping) {
+						if (i < 9 && Operator.shortcut(Config.keymap.select_material, ShortcutDown)) {
+							var number = Std.string(i + 1) ;
+							var width = ui.ops.font.width(ui.fontSize, number) + 10;
+							var height = ui.ops.font.height(ui.fontSize);
+							ui.g.color = ui.t.TEXT_COL;
+							ui.g.fillRect(uix, uiy, width, height);
+							ui.g.color = ui.t.ACCENT_COL;
+							ui.g.drawString(number, uix + 5, uiy);
+						}
+					}
+
 					if (state == State.Started && ui.inputY > ui._windowY) {
 						if (Context.material != Project.materials[i]) {
 							Context.selectMaterial(i);

--- a/Sources/arm/ui/UISidebar.hx
+++ b/Sources/arm/ui/UISidebar.hx
@@ -269,6 +269,7 @@ class UISidebar {
 				for (i in 1...10) if (kb.started(i + "")) Context.selectMaterial(i - 1);
 			}
 			else if (Operator.shortcut(Config.keymap.select_layer, ShortcutDown)) {
+				UISidebar.inst.hwnd0.redraws = 2;
 				for (i in 1...10) if (kb.started(i + "")) Context.selectLayer(i - 1);
 			}
 		}

--- a/Sources/arm/ui/UISidebar.hx
+++ b/Sources/arm/ui/UISidebar.hx
@@ -265,6 +265,7 @@ class UISidebar {
 		var isTyping = ui.isTyping || UIView2D.inst.ui.isTyping || UINodes.inst.ui.isTyping;
 		if (!isTyping) {
 			if (Operator.shortcut(Config.keymap.select_material, ShortcutDown)) {
+				UISidebar.inst.hwnd1.redraws = 2;
 				for (i in 1...10) if (kb.started(i + "")) Context.selectMaterial(i - 1);
 			}
 			else if (Operator.shortcut(Config.keymap.select_layer, ShortcutDown)) {


### PR DESCRIPTION
It is always painful to select materials and layers via shortcut because the user has to count.
Let's change this and make it intuitive. Hold shift (or a custom shortcut) to preview material numbers. Hold alt (or custom shortcut) to preview layer numbers.
![grafik](https://user-images.githubusercontent.com/28649121/164785489-c22cd6ff-efd8-43e6-b7f4-f0f1fb06342d.png) ![grafik](https://user-images.githubusercontent.com/28649121/164785507-297e4326-0ce3-49a7-8303-f725ea0b97a8.png)
