### PR TITLE
Live search for browser

### DIFF
--- a/Sources/arm/ui/TabBrowser.hx
+++ b/Sources/arm/ui/TabBrowser.hx
@@ -1,5 +1,6 @@
 package arm.ui;
 
+import kha.input.KeyCode;
 import zui.Zui;
 import zui.Id;
 import arm.sys.Path;
@@ -54,8 +55,12 @@ class TabBrowser {
 			if (ui.button(tr("Refresh")) || (inFocus && ui.isKeyPressed && ui.key == kha.input.KeyCode.F5)) {
 				refresh = true;
 			}
-			hsearch.text = ui.textInput(hsearch, tr("Search"));
-			if (hsearch.text != "" && ui.button(tr("X"))) {
+			hsearch.text = ui.textInput(hsearch, tr("Search"), Align.Left, true, true);
+			if (ui.isHovered) ui.tooltip(tr("Press ctrl+f to search and esc to cancel"));
+			if (ui.isCtrlDown && ui.isKeyPressed && ui.key == KeyCode.F) { // start searching via ctrl+f
+				ui.startTextEdit(hsearch);
+			}
+			if (hsearch.text != "" && (ui.button(tr("X")) || ui.isEscapeDown)) {
 				hsearch.text = "";
 			}
 			ui.endSticky();

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -45,7 +45,6 @@ class UINodes {
 	var recompileMatFinal = false;
 	var nodeSearchSpawn: TNode = null;
 	var nodeSearchOffset = 0;
-	var nodeSearchLast = "";
 	var lastCanvas: TNodeCanvas = null;
 	var lastNodeSelected: TNode = null;
 	var releaseLink = false;
@@ -469,22 +468,16 @@ class UINodes {
 		var first = true;
 		UIMenu.draw(function(ui: Zui) {
 			ui.fill(0, 0, ui._w / ui.SCALE(), ui.t.ELEMENT_H * 8, ui.t.SEPARATOR_COL);
-			ui.textInput(searchHandle, "");
+			var search = ui.textInput(searchHandle, "", Left, true, true);
 			ui.changed = false;
 			if (first) {
 				first = false;
-				ui.startTextEdit(searchHandle); // Focus search bar
-				ui.textSelected = searchHandle.text;
 				searchHandle.text = "";
-				nodeSearchLast = "";
+				ui.startTextEdit(searchHandle); // Focus search bar
 			}
-			var search = searchHandle.text;
-			if (ui.textSelected != "") search = ui.textSelected;
 
-			if (search != nodeSearchLast) {
-				nodeSearchOffset = 0;
-				nodeSearchLast = search;
-			}
+			if (searchHandle.changed) nodeSearchOffset = 0;
+			
 			if (ui.isKeyPressed) { // Move selection
 				if (ui.key == kha.input.KeyCode.Down && nodeSearchOffset < 6) nodeSearchOffset++;
 				if (ui.key == kha.input.KeyCode.Up && nodeSearchOffset > 0) nodeSearchOffset--;


### PR DESCRIPTION
This PR implements live search for the browser proposed by @sanya-2005 in #1222
In addition I added `ctrl+f` as a non customizable shortcut to start searching and `esc` to stop it again.

Aditionally I changed the node search to use the new live text input feature. It makes the code shorter and more readable imho. From an ArmorPaint perspective you could make `textSelected` a private attribute of zui.
