### PR TITLE
Improve text tool

### DIFF
--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -313,7 +313,7 @@ class UIHeader {
 				if (Context.tool == ToolText) {
 					var h = Id.handle();
 					h.text = Context.textToolText;
-					Context.textToolText = ui.textInput(h, "");
+					Context.textToolText = ui.textInput(h, "", Left, true, true);
 					if (h.changed) {
 						ui.g.end();
 						RenderUtil.makeTextPreview();

--- a/Sources/arm/ui/UIHeader.hx
+++ b/Sources/arm/ui/UIHeader.hx
@@ -313,7 +313,14 @@ class UIHeader {
 				if (Context.tool == ToolText) {
 					var h = Id.handle();
 					h.text = Context.textToolText;
+					var w = ui._w;
+					if (ui.textSelectedHandle == h || ui.submitTextHandle == h) {
+						ui._w *= 3;
+					}
+					
 					Context.textToolText = ui.textInput(h, "", Left, true, true);
+					ui._w = w;
+
 					if (h.changed) {
 						ui.g.end();
 						RenderUtil.makeTextPreview();


### PR DESCRIPTION
Tried to improve the text tool and to (practically) fix https://github.com/armory3d/armorpaint/issues/1154

1. Now live update is used to update the text decal while typing
2. The textInput's width is increased if it is active. Imho the current width is too small. The factor 3 was determined by comparing the overall width of all tool's headers. Currently the picker tool is is the tool with the highest width.