### PR TITLE
Fix a freeze when undoing Merge Down if top layer has a mask

### DIFF
--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -465,6 +465,9 @@ class History {
 
 		var step = push(tr("Merge Layers"));
 		step.layer -= 1; // Merge down
+		if (Context.layer.hasMasks()) {
+			step.layer -= Context.layer.getMasks().length;
+		}
 		steps.shift(); // Merge consumes 2 steps
 		undos--;
 		// TODO: use undo layer in Layers.mergeDown to save memory


### PR DESCRIPTION
Fixes #1089 and partially #1382. More specifically, this PR fixes an UI freeze when undoing "Merge Down" command when merging down a layer with one or more masks.

The cause of the freeze was the asymmetry between Layers.mergeDown and History.mergeLayers. Layers.mergeDown applies all of the masks both of layers have, and History.mergeLayers didn't take that into account. Because of that, the layer that was saved into the undo step was off by the number of the masks applied, which resulted in an exception being thrown when History.undo tried to delete a non-existent layer.

This PR does not fix restoring the mask layers themselves, though (#1001). 