### PR TITLE
Undo system improvements

### DIFF
--- a/Sources/arm/App.hx
+++ b/Sources/arm/App.hx
@@ -744,7 +744,7 @@ class App {
 		raw.keymap = "default.json";
 		raw.theme = "default.json";
 		raw.server = "https://armorpaint.fra1.digitaloceanspaces.com";
-		raw.undo_steps = 4;
+		raw.undo_steps = 32;
 		raw.pressure_radius = true;
 		raw.pressure_hardness = true;
 		raw.pressure_angle = false;

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -49,9 +49,10 @@ class History {
 			Context.layer.delete();
 			Context.layer = Project.layers[step.layer > 0 ? step.layer - 1 : 0];
 		}
-		else if (step.name == tr("Delete Layer") || step.name == tr("Delete Layer (internal)")) {
+		else if (step.name == tr("Delete Layer")) {
 			var parent = step.layer_parent > 0 ? LayerSlot.findById(step.layer_parent) : null;
-			var position = parent == null ? step.layer : Project.layers.indexOf(parent) - step.layer;
+			// Always insert at the parent position if the parent is set
+			var position = parent == null ? step.layer : Project.layers.indexOf(parent);
 			var l = new LayerSlot("", step.layer_type, parent, step.layer_id);
 			Project.layers.insert(position, l);
 			Context.setLayer(l);
@@ -451,7 +452,7 @@ class History {
 
 	public static function deleteLayer2(l: LayerSlot) {
 		swapActive2(l);
-		push(tr("Delete Layer (internal)"), l);
+		push(tr("Delete Layer"), l);
 	}
 
 	public static function clearLayer() {

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -91,7 +91,7 @@ class History {
 			Project.layers[step.prev_order] = Project.layers[step.layer];
 			Project.layers[step.layer] = target;
 		}
-		else if (step.name == tr("Merge Layers") || step.name == tr("Merge Group (internal)") || step.name == tr("Apply Mask") || step.name == tr("Apply Masks (internal)")) {
+		else if (step.name == tr("Merge Layers") || step.name == tr("Merge Group") || step.name == tr("Apply Mask (internal)") || step.name == tr("Apply Masks")) {
 			// Each step can have more than one child and they may not be laid out
 			// sequentially since there could be more than one step in between them.
 			// This applies to _all_ children on all levels of nesting.
@@ -101,7 +101,7 @@ class History {
 				numChildrenTotal += undoInternal(active - i - numChildrenTotal);
 			}
 		}
-		else if (step.name == tr("Apply Mask (internal)")) {
+		else if (step.name == tr("Apply Mask")) {
 			undoI = undoI - 1 < 0 ? Config.raw.undo_steps - 1 : undoI - 1;
 			var lay = undoLayers[undoI];
 			Context.setLayer(LayerSlot.findById(step.layer_id));
@@ -453,7 +453,7 @@ class History {
 
 	public static function applyMask(l: LayerSlot) {
 		swapActive2(l);
-		push(tr("Apply Mask (internal)"), l);
+		push(tr("Apply Mask"), l);
 	}
 
 	public static function clearLayer() {
@@ -472,15 +472,15 @@ class History {
 	}
 
 	public static function beginMergeGroup() {
-		begin(tr("Merge Group (internal)"));
+		begin(tr("Merge Group"));
 	}
 
 	public static function beginApplyMask() {
-		begin(tr("Apply Mask"));
+		begin(tr("Apply Mask (internal)"));
 	}
 
 	public static function beginApplyMasks() {
-		begin(tr("Apply Masks (internal)"));
+		begin(tr("Apply Masks"));
 	}
 
 	// public static function applyMask() {

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -52,30 +52,6 @@ class History {
 		else if (step.name == tr("Delete Layer")) {
 			var parent = step.layer_parent > 0 ? LayerSlot.findById(step.layer_parent) : null;
 			var position = step.layer;
-			if (parent != null) { 
-				// If this layer has a parent, insert it either at parent's position
-				// or below the position of the last child. This is needed because children
-				// are restored in the reverse order, and if we just insert them at the 
-				// parent position, the resulting order will be reversed.
-				// Same applies to masks.
-				position = Project.layers.indexOf(parent);
-				if (step.layer_type == LayerSlotType.SlotLayer) {
-					var children = parent.getChildren();
-					if (children != null) {
-						position -= children.length;
-						// Also account for any masks any of the children may have
-						for (l in parent.getChildren()) {
-							var masks = l.getMasks();
-							if (masks != null) {
-								position -= masks.length;
-					}
-				} else if (step.layer_type == LayerSlotType.SlotMask) {
-					var masks = parent.getMasks();
-					if (masks != null) {
-						position -= masks.length;
-					}
-				}
-			}
 			var l = new LayerSlot("", step.layer_type, parent, step.layer_id);
 			Project.layers.insert(position, l);
 			Context.setLayer(l);
@@ -116,6 +92,7 @@ class History {
 			for (i in 1...step.num_children + 1) {
 				numChildrenTotal += undoInternal(active - i - numChildrenTotal);
 			}
+		}
 		else if (step.name == tr("Apply Mask (internal)")) {
 			undoI = undoI - 1 < 0 ? Config.raw.undo_steps - 1 : undoI - 1;
 			var lay = undoLayers[undoI];
@@ -215,6 +192,7 @@ class History {
 				active += 1;
 				undos++;
 				redos--;
+			}
 			var step = steps[active];
 
 			if (step.name == tr("New Layer") || step.name == tr("New Black Mask") || step.name == tr("New White Mask") || step.name == tr("New Fill Mask")) {
@@ -629,11 +607,6 @@ class History {
 		var bpos = Project.brushes.indexOf(Context.brush);
 		
 		var layer_type = layer.isMask() ? SlotMask : layer.isGroup() ? SlotGroup : SlotLayer;
-
-		if (layer.parent != null) {
-			// Save position relative to the parent layer
-			lpos = Project.layers.indexOf(layer.parent) - lpos;
-		}
 
 		var step: TStep = {
 			name: name,

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -57,10 +57,18 @@ class History {
 				// or below the position of the last child. This is needed because children
 				// are restored in the reverse order, and if we just insert them at the 
 				// parent position, the resulting order will be reversed.
+				// Same applies to masks.
 				position = Project.layers.indexOf(parent);
-				var children = parent.getChildren();
-				if (children != null) {
-					position -= children.length;
+				if (step.layer_type == LayerSlotType.SlotLayer) {
+					var children = parent.getChildren();
+					if (children != null) {
+						position -= children.length;
+					}
+				} else if (step.layer_type == LayerSlotType.SlotMask) {
+					var masks = parent.getMasks();
+					if (masks != null) {
+						position -= masks.length;
+					}
 				}
 			}
 			var l = new LayerSlot("", step.layer_type, parent, step.layer_id);

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -37,6 +37,14 @@ class History {
 		var step = steps[active];
 		var numChildrenTotal = 0;
 
+		#if arm_debug
+		trace('Undoing step:${active} name:"${step.name}" layer:${step.layer} layer_parent:${step.layer_parent}');
+		trace('Before:');
+		for (l in Project.layers) {
+			trace('    id:${l.id} parent:${l.parent != null ? l.parent.id : -1} name:"${l.name}"');
+		}
+		#end
+
 		if (step.name == tr("New Layer") || step.name == tr("New Black Mask") || step.name == tr("New White Mask") || step.name == tr("New Fill Mask")) {
 			Context.layer = LayerSlot.findById(step.layer_id);
 			Context.layer.delete();
@@ -180,6 +188,15 @@ class History {
 		UISidebar.inst.hwnd1.redraws = 2;
 		Context.ddirty = 2;
 		if (UIView2D.inst.show) UIView2D.inst.hwnd.redraws = 2;
+
+		#if arm_debug
+		trace('Done undoing step:${active} name:"${step.name}" layer:${step.layer} layer_parent:${step.layer_parent}');
+		trace('After:');
+		for (l in Project.layers) {
+			trace('    id:${l.id} parent:${l.parent != null ? l.parent.id : -1} name:"${l.name}"');
+		}
+		#end
+
 		// Return total number of steps consumed during execution of this method
 		// (including any steps consumed during recursion)
 		return numChildrenTotal + step.num_children;

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -51,8 +51,18 @@ class History {
 		}
 		else if (step.name == tr("Delete Layer")) {
 			var parent = step.layer_parent > 0 ? LayerSlot.findById(step.layer_parent) : null;
-			// Always insert at the parent position if the parent is set
-			var position = parent == null ? step.layer : Project.layers.indexOf(parent);
+			var position = step.layer;
+			if (parent != null) { 
+				// If this layer has a parent, insert it either at parent's position
+				// or below the position of the last child. This is needed because children
+				// are restored in the reverse order, and if we just insert them at the 
+				// parent position, the resulting order will be reversed.
+				position = Project.layers.indexOf(parent);
+				var children = parent.getChildren();
+				if (children != null) {
+					position -= children.length;
+				}
+			}
 			var l = new LayerSlot("", step.layer_type, parent, step.layer_id);
 			Project.layers.insert(position, l);
 			Context.setLayer(l);

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -282,6 +282,12 @@ class History {
 				Context.layer = Project.layers[step.layer];
 				iron.App.notifyOnInit(Layers.mergeDown);
 			}
+			else if (step.name == tr("Merge Group")) {
+				function _next() {
+					Layers.mergeGroup(Project.layers[step.layer]);
+				}
+				App.notifyOnNextFrame(_next);
+			}
 			else if (step.name == tr("Apply Mask")) {
 				Context.layer = Project.layers[step.layer];
 					if (Context.layer.isGroupMask()) {

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -201,6 +201,10 @@ class History {
 	public static function redo() {
 		if (redos > 0) {
 			var active = steps.length - redos;
+			while (steps[active].internal) {
+				active += 1;
+				undos++;
+				redos--;
 			var step = steps[active];
 
 			if (step.name == tr("New Layer") || step.name == tr("New Black Mask") || step.name == tr("New White Mask") || step.name == tr("New Fill Mask")) {
@@ -270,8 +274,7 @@ class History {
 				Project.layers[step.layer] = target;
 			}
 			else if (step.name == tr("Merge Layers")) {
-				Context.layer = Project.layers[step.layer + 1];
-				iron.App.notifyOnInit(redoMergeLayers);
+				Context.layer = Project.layers[step.layer];
 				iron.App.notifyOnInit(Layers.mergeDown);
 			}
 			else if (step.name == tr("Apply Mask")) {
@@ -459,13 +462,7 @@ class History {
 	}
 
 	public static function beginMergeGroup() {
-		begin(tr("Merge Layers"));
-	}
-
-	public static function mergeLayers(l0: LayerSlot, l1: LayerSlot) {
-		copyToUndo(l0.id, undoI, l0.isMask());
-		copyToUndo(l1.id, undoI, l1.isMask());
-		push(tr("Merge Layers (internal)"));
+		begin(tr("Merge Group (internal)"));
 	}
 
 	public static function beginApplyMask() {
@@ -475,6 +472,18 @@ class History {
 	public static function beginApplyMasks() {
 		begin(tr("Apply Masks (internal)"));
 	}
+
+	// public static function applyMask() {
+	// 	if (Context.layer.isGroupMask()) {
+	// 		var group = Context.layer.parent;
+	// 		var layers = group.getChildren();
+	// 		layers.insert(0, Context.layer);
+	// 		copyMergingLayers2(layers);	
+	// 	}
+	// 	else copyMergingLayers2([Context.layer, Context.layer.parent]);
+	// 	push(tr("Apply Mask"));
+	// }
+
 	public static function invertMask() {
 		push(tr("Invert Mask"));
 	}

--- a/Sources/arm/History.hx
+++ b/Sources/arm/History.hx
@@ -50,7 +50,7 @@ class History {
 			Context.layer = Project.layers[step.layer > 0 ? step.layer - 1 : 0];
 		}
 		else if (step.name == tr("Delete Layer")) {
-			var parent = step.layer_parent > 0 ? LayerSlot.findById(step.layer_parent) : null;
+			var parent = step.layer_parent >= 0 ? LayerSlot.findById(step.layer_parent) : null;
 			var position = step.layer;
 			var l = new LayerSlot("", step.layer_type, parent, step.layer_id);
 			Project.layers.insert(position, l);

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -431,14 +431,19 @@ class Layers {
 	}
 
 	public static function mergeDown() {
+		History.beginMergeLayers();
+		
 		var l1 = Context.layer;
 
 		if (l1.isGroup()) {
 			l1 = mergeGroup(l1);
 		}
-		else if (l1.hasMasks()) { // It is a layer
-			applyMasks(l1);
-			Context.setLayer(l1);
+		else { // It is a layer
+			History.deleteLayer2(l1);
+			if (l1.hasMasks()) { 
+				applyMasks(l1);
+				Context.setLayer(l1);
+			}
 		}
 
 		var l0 = Project.layers[Project.layers.indexOf(l1) - 1];
@@ -446,14 +451,22 @@ class Layers {
 		if (l0.isGroup()) {
 			l0 = mergeGroup(l0);
 		}
-		else if (l0.hasMasks()) { // It is a layer
-			applyMasks(l0);
-			Context.setLayer(l0);
+		else {  // It is a layer
+			History.deleteLayer2(l0);
+			if (l0.hasMasks()) {
+				applyMasks(l0);
+				Context.setLayer(l0);
+			}
 		}
 
 		mergeLayer(l0, l1);
 		l1.delete();
+		
+		History.newLayer();
 		Context.setLayer(l0);
+		
+		History.end();
+		
 		Context.layerPreviewDirty = true;
 	}
 
@@ -468,7 +481,6 @@ class Layers {
 
 		for (i in 0...children.length - 1) {
 			Context.setLayer(children[children.length - 1 - i]);
-			History.mergeLayers();
 			Layers.mergeDown();
 		}
 

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -468,19 +468,21 @@ class Layers {
 		}
 		else {
 			// This should be done _before_ History.newLayer (or strange things will happen).
-			// What we do here is we back up layer l0 as it will be used as a combined layer,
-			// but we also want to delete the combined layer on undo.
-			// The undo steps are executed in reverse order, so if we want our layer to
-			// exist after undoing this command, we should do deleteLayer first and newLayer second.
-			History.deleteLayer2(l0);
-			// Only delete the combined layer on undo if it wasn't a group, because if it was a group 
-			// the undo logic for "Merge Group" will delete it automatically (because it deletes the 
-			// layer that was the result of merging the group).
-			History.newLayer2(l0);
+			// Undoing of applyMasks should happen before History.newLayer, because the undo 
+			// steps are executed in reverse order.
 			if (l0.hasMasks()) {
 				applyMasks(l0);
 				Context.setLayer(l0);
 			}
+
+			// Back up layer l0 as it will be used as a combined layer,
+			// but we also want to delete the combined layer on undo.
+			History.deleteLayer2(l0);
+
+			// Only delete the combined layer on undo if it wasn't a group, because if it was a group 
+			// the undo logic for "Merge Group" will delete it automatically (because it deletes the 
+			// layer that was the result of merging the group).
+			History.newLayer2(l0);
 		}
 
 		mergeLayer(l0, l1);

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -451,8 +451,17 @@ class Layers {
 		if (l0.isGroup()) {
 			l0 = mergeGroup(l0);
 		}
-		else {  // It is a layer
+		else {
+			// This should be done _before_ History.newLayer (or strange things will happen).
+			// What we do here is we back up layer l0 as it will be used as a combined layer,
+			// but we also want to delete the combined layer on undo.
+			// The undo steps are executed in reverse order, so if we want our layer to
+			// exist after undoing this command, we should do deleteLayer first and newLayer second.
 			History.deleteLayer2(l0);
+			// Only delete the combined layer on undo if it wasn't a group, because if it was a group 
+			// the undo logic for "Merge Group" will delete it automatically (because it deletes the 
+			// layer that was the result of merging the group).
+			History.newLayer2(l0);
 			if (l0.hasMasks()) {
 				applyMasks(l0);
 				Context.setLayer(l0);
@@ -463,7 +472,6 @@ class Layers {
 		l1.delete();
 		
 		Context.setLayer(l0);
-		History.newLayer2(l0);
 		
 		History.end();
 		

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -439,7 +439,6 @@ class Layers {
 			l1 = mergeGroup(l1);
 		}
 		else { // It is a layer
-			History.deleteLayer2(l1);
 			if (l1.hasMasks()) { 
 				applyMasks(l1);
 				Context.setLayer(l1);
@@ -469,6 +468,7 @@ class Layers {
 		}
 
 		mergeLayer(l0, l1);
+		History.deleteLayer2(l1);
 		l1.delete();
 		
 		Context.setLayer(l0);

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -420,14 +420,30 @@ class Layers {
 	public static function applyMasks(l: LayerSlot) {
 		var masks = l.getMasks();
 
-		if (masks != null) {
-			for (i in 0...masks.length - 1) {
-				mergeLayer(masks[i + 1], masks[i]);
-				masks[i].delete();
-			}
-			masks[masks.length - 1].applyMask();
-			Context.layerPreviewDirty = true;
+		if (masks == null) {
+			return;
 		}
+
+		History.beginApplyMasks();
+
+		// Copy masks before merging them
+		for (i in 0...masks.length - 1) {
+			History.deleteLayer2(masks[i]);
+		}
+
+		for (i in 0...masks.length - 1) {
+			mergeLayer(masks[i + 1], masks[i]);
+			masks[i].delete();
+		}
+
+		// Apply the merged mask. 
+		// This will also record all neccessary steps to restore the layer on undo
+		// (and also will remove the merged mask)
+		masks[masks.length - 1].applyMask();
+
+		History.end();
+
+		Context.layerPreviewDirty = true;
 	}
 
 	public static function mergeDown() {

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -462,8 +462,8 @@ class Layers {
 		mergeLayer(l0, l1);
 		l1.delete();
 		
-		History.newLayer();
 		Context.setLayer(l0);
+		History.newLayer2(l0);
 		
 		History.end();
 		
@@ -473,6 +473,7 @@ class Layers {
 	public static function mergeGroup(l: LayerSlot) {
 		if (!l.isGroup()) return null;
 
+		History.beginMergeGroup();
 		var children = l.getChildren();
 
 		if (children.length == 1 && children[0].hasMasks(false)) {
@@ -497,7 +498,9 @@ class Layers {
 		children[0].parent = null;
 		children[0].name = l.name;
 		if (children[0].fill_layer != null) children[0].toPaintLayer();
+		History.deleteLayer2(l);
 		l.delete();
+		History.end();
 		return children[0];
 	}
 

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -503,12 +503,25 @@ class Layers {
 			Layers.applyMask(children[0], masks[masks.length - 1]);
 		}
 
+		if (children.length == 1) {
+			// A special case: the group only has one child. Because of that, it won't be
+			// saved to history in the `for` cycle just above where we merge down all the 
+			// children. Which is why we have to save it here manually.
+			History.deleteLayer2(children[0]);
+
+			// But then we also need to delete it, because it won't be deleted by 
+			// undoing "Merge Layers" (since we never called "Merge Layers" in this case).
+			History.newLayer2(children[0]);
+		}
 		children[0].parent = null;
 		children[0].name = l.name;
 		if (children[0].fill_layer != null) children[0].toPaintLayer();
+		
 		History.deleteLayer2(l);
 		l.delete();
+
 		History.end();
+		
 		return children[0];
 	}
 

--- a/Sources/arm/Layers.hx
+++ b/Sources/arm/Layers.hx
@@ -513,6 +513,7 @@ class Layers {
 		var masks = l.getMasks();
 		if (masks != null) {
 			for (i in 0...masks.length - 1) {
+				// TODO: preserve the masks for undo with History.deleteLayer2(masks[i]);
 				mergeLayer(masks[i + 1], masks[i]);
 				masks[i].delete();
 			}

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -231,6 +231,16 @@ class LayerSlot {
 	}
 
 	public function applyMask() {
+		// First, we back up the current mask layer, then we back up parent, then we mark the layer 
+		// with the applied mask for deletion.
+		// This is done in this order because the undo system will replay these steps in reverse order,
+		// and if we restore the mask after we delete the resulting layer the mask will be deleted too
+		// because its parent is still set to resulting layer. Also, parent layer should exist when the
+		// mask is restored.
+		History.beginApplyMask();
+		History.deleteLayer2(this);
+		History.deleteLayer2(parent);
+		History.newLayer2(parent);
 		if (parent.fill_layer != null) {
 			parent.toPaintLayer();
 		}
@@ -243,6 +253,7 @@ class LayerSlot {
 			Layers.applyMask(parent, this);
 		}
 		delete();
+		History.end();
 	}
 
 	public function duplicate(): LayerSlot {

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -42,11 +42,17 @@ class LayerSlot {
 	public var paintSubs = true;
 	public var decalMat = iron.math.Mat4.identity(); // Decal layer
 
-	public function new(ext = "", type = SlotLayer, parent: LayerSlot = null) {
+	public static var lastId = 0;
+
+	public function new(ext = "", type = SlotLayer, parent: LayerSlot = null, id: Int = -1) {
 		if (ext == "") {
-			id = 0;
-			for (l in Project.layers) if (l.id >= id) id = l.id + 1;
-			ext = id + "";
+			if (id < 0) {
+				this.id = lastId;
+				lastId += 1;
+			} else {
+				this.id = id;
+			}
+			ext = this.id + "";
 		}
 		this.ext = ext;
 		this.parent = parent;
@@ -628,5 +634,14 @@ class LayerSlot {
 		}
 
 		for (m in Project.materials) TabLayers.remapLayerPointers(m.canvas.nodes, TabLayers.fillLayerMap(pointers));
+	}
+
+	public static function findById(id: Int): LayerSlot {
+		for (l in Project.layers) {
+			if (l.id == id) {
+				return l;
+			}
+		}
+		return null;
 	}
 }

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -170,6 +170,9 @@ class LayerSlot {
 			var _texpaint_preview = texpaint_preview;
 			texpaint_preview = other.texpaint_preview;
 			other.texpaint_preview = _texpaint_preview;
+			var _fill_layer = fill_layer;
+			fill_layer = other.fill_layer;
+			other.fill_layer = _fill_layer;
 		}
 
 		if (isLayer() && other.isLayer()) {

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -239,8 +239,8 @@ class LayerSlot {
 		// mask is restored.
 		History.beginApplyMask();
 		History.deleteLayer2(this);
-		History.deleteLayer2(parent);
-		History.newLayer2(parent);
+		History.applyMask(parent);
+
 		if (parent.fill_layer != null) {
 			parent.toPaintLayer();
 		}
@@ -384,6 +384,10 @@ class LayerSlot {
 		}
 	}
 
+	// TODO: these are used internally by several methods but don't
+	// record undo steps for themselves. I've added a hack that copies
+	// fill_layer when swapping as a stop-gap measure, but there's no
+	// guarantee that it actually works correctly.
 	public function toFillLayer() {
 		Context.setLayer(this);
 		fill_layer = Context.material;

--- a/Sources/arm/data/LayerSlot.hx
+++ b/Sources/arm/data/LayerSlot.hx
@@ -47,6 +47,9 @@ class LayerSlot {
 	public function new(ext = "", type = SlotLayer, parent: LayerSlot = null, id: Int = -1) {
 		if (ext == "") {
 			if (id < 0) {
+				// TODO: this is just a monotonically increasing id. It probably shouldn't be used
+				// in UI. A good practice is to have different increasing IDs for different kinds of
+				// layers, ie. Group 1, Layer 1, Layer 2, Group 2, Layer 3, Mask 1 etc.
 				this.id = lastId;
 				lastId += 1;
 			} else {
@@ -58,10 +61,10 @@ class LayerSlot {
 		this.parent = parent;
 
 		if (type == SlotGroup) {
-			name = "Group " + (id + 1);
+			name = "Group " + (this.id + 1);
 		}
 		else if (type == SlotLayer) {
-			name = "Layer " + (id + 1);
+			name = "Layer " + (this.id + 1);
 			var format = App.bitsHandle.position == Bits8  ? "RGBA32" :
 						 App.bitsHandle.position == Bits16 ? "RGBA64" :
 						 									 "RGBA128";
@@ -94,7 +97,7 @@ class LayerSlot {
 			texpaint_preview = Image.createRenderTarget(RenderUtil.layerPreviewSize, RenderUtil.layerPreviewSize, TextureFormat.RGBA32);
 		}
 		else { // Mask
-			name = "Mask " + (id + 1);
+			name = "Mask " + (this.id + 1);
 			var format = "RGBA32"; // Full bits for undo support, R8 is used
 			blending = BlendAdd;
 

--- a/Sources/arm/io/ImportArm.hx
+++ b/Sources/arm/io/ImportArm.hx
@@ -231,6 +231,10 @@ class ImportArm {
 			}
 
 			for (l in Project.layers) l.unload();
+			
+			// TODO: check if this is enough to keep ids consistent across project reloads
+			LayerSlot.lastId = 0;
+			
 			Project.layers = [];
 			for (i in 0...project.layer_datas.length) {
 				var ld = project.layer_datas[i];

--- a/Sources/arm/io/ImportMesh.hx
+++ b/Sources/arm/io/ImportMesh.hx
@@ -19,6 +19,10 @@ class ImportMesh {
 
 	static var clearLayers = true;
 
+	#if arm_debug
+	static var timer: Float;
+	#end
+
 	public static function run(path: String, _clearLayers = true, replaceExisting = true) {
 		if (!Path.isMesh(path)) {
 			if (!Context.enableImportPlugin(path)) {
@@ -31,7 +35,7 @@ class ImportMesh {
 		Context.layerFilter = 0;
 
 		#if arm_debug
-		var timer = iron.system.Time.realTime();
+		timer = iron.system.Time.realTime();
 		#end
 
 		var p = path.toLowerCase();

--- a/Sources/arm/ui/TabHistory.hx
+++ b/Sources/arm/ui/TabHistory.hx
@@ -23,7 +23,8 @@ class TabHistory {
 				#if arm_debug
 				var formatted_name = '${step.name} (${step.num_children})';
 				if (step.internal)
-					formatted_name = '<internal>' + formatted_name;
+					formatted_name = '<internal> ' + formatted_name;
+				formatted_name = '${i} ' + formatted_name;
 				ui.text(formatted_name);
 				#else
 				ui.text(step.name);

--- a/Sources/arm/ui/TabHistory.hx
+++ b/Sources/arm/ui/TabHistory.hx
@@ -7,11 +7,28 @@ class TabHistory {
 		var ui = UISidebar.inst.ui;
 		if (ui.tab(UISidebar.inst.htab0, tr("History"))) {
 			for (i in 0...History.steps.length) {
+				var step = History.steps[i];
+				
+				#if !arm_debug
+				if (step.internal) {
+					continue;
+				}
+				#end
+				
 				var active = History.steps.length - 1 - History.redos;
 				if (i == active) {
 					ui.fill(0, 0, ui._windowW, ui.t.ELEMENT_H, ui.t.HIGHLIGHT_COL);
 				}
-				ui.text(History.steps[i].name);
+
+				#if arm_debug
+				var formatted_name = '${step.name} (${step.num_children})';
+				if (step.internal)
+					formatted_name = '<internal>' + formatted_name;
+				ui.text(formatted_name);
+				#else
+				ui.text(step.name);
+				#end
+				
 				if (ui.isReleased) { // Jump to undo step
 					var diff = i - active;
 					while (diff > 0) {

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -605,7 +605,6 @@ class TabLayers {
 			if (l.isMask() && ui.button(tr("Apply"), Left)) {
 				function _init() {
 					Context.layer = l;
-					History.applyMask();
 					l.applyMask();
 					Context.setLayer(l.parent);
 					MakeMaterial.parseMeshMaterial();

--- a/Sources/arm/ui/TabLayers.hx
+++ b/Sources/arm/ui/TabLayers.hx
@@ -623,7 +623,6 @@ class TabLayers {
 			if (ui.button(tr("Merge Down"), Left)) {
 				function _init() {
 					Context.setLayer(l);
-					History.mergeLayers();
 					Layers.mergeDown();
 					if (Context.layer.fill_layer != null) Context.layer.toPaintLayer();
 				}


### PR DESCRIPTION
Ref: #792

This PR partially implements a refactoring of the undo system I was talking about in my previous PR. 

You can see it in action:

https://user-images.githubusercontent.com/170835/174704834-43c3802c-7ec2-4f16-b840-20d8af510b9a.mp4

Here, I create a couple of fill layers, put them in a group, add masks to each of them and then I merge down the group to the bottom layer. Then I repeatedly undo and redo this action.

More specifically, this PR implements an alternative approach to record history: instead of calling a `History.{action}()` before calling an action, now we call `History.begin{action}()` and `History.end()` _inside_ the `action()` method itself. 

The goal is to allow actions to record undo steps not only for themselves but also for any nested actions which greatly simplifies implementing undo and redo operations for complex actions such as `Merge Down`. The system also allows for correct recording of undo steps for recursive actions. 

However, there is still room for improvement. 

A single biggest issue is that this approach greatly increases number of the undo steps being recorded. This is why I increased default maximum number of undo steps to 32. Since each undo step has an associated layer, this increases memory requirements since there is currently no way to swap the layer data to disk.