### PR TITLE
Fix Linux startup SIGSEGV in display enumeration and Vulkan constant buffer setup

### DIFF
--- a/base/sources/backends/linux_system.c
+++ b/base/sources/backends/linux_system.c
@@ -151,15 +151,15 @@ void iron_display_init() {
 	RROutput            primary_output   = XRRGetOutputPrimary(x11_ctx.display, root_window);
 
 	for (int i = 0; i < screen_resources->noutput; i++) {
-		if (i >= MAXIMUM_DISPLAYS) {
-			iron_error("Too many screens (maximum %i)", MAXIMUM_DISPLAYS);
-			break;
-		}
-
 		XRROutputInfo *output_info = XRRGetOutputInfo(x11_ctx.display, screen_resources, screen_resources->outputs[i]);
 		if (output_info->connection != RR_Connected || output_info->crtc == None) {
 			XRRFreeOutputInfo(output_info);
 			continue;
+		}
+		if (x11_ctx.num_displays >= MAXIMUM_DISPLAYS) {
+			iron_error("Too many screens (maximum %i)", MAXIMUM_DISPLAYS);
+			XRRFreeOutputInfo(output_info);
+			break;
 		}
 
 		XRRCrtcInfo *crtc_info = XRRGetCrtcInfo(x11_ctx.display, screen_resources, output_info->crtc);

--- a/base/sources/backends/linux_system.h
+++ b/base/sources/backends/linux_system.h
@@ -8,7 +8,7 @@
 #include <X11/extensions/Xrandr.h>
 #include <iron_system.h>
 
-#define MAXIMUM_DISPLAYS 8
+#define MAXIMUM_DISPLAYS 32
 
 struct iron_x11_window {
 	int                display_index;

--- a/base/sources/iron_gpu.h
+++ b/base/sources/iron_gpu.h
@@ -217,6 +217,7 @@ void  gpu_set_constant_buffer(gpu_buffer_t *buffer, int offset, size_t size);
 void  gpu_get_render_target_pixels(gpu_texture_t *render_target, uint8_t *data);
 void  gpu_set_texture(int unit, gpu_texture_t *texture);
 void  gpu_use_linear_sampling(bool b);
+int   gpu_uniform_buffer_align(void);
 char *gpu_device_name();
 
 bool gpu_raytrace_supported(void);


### PR DESCRIPTION
## Summary
Fixes Linux startup segmentation faults by addressing two startup crash paths:
1. Display enumeration bounds handling in X11 display init.
2. Vulkan constant-buffer alignment/descriptor safety during early draw setup.

## Changes
- `base/sources/backends/linux_system.c`
  - Correct display limit guard to use `x11_ctx.num_displays` after filtering disconnected outputs.
- `base/sources/backends/linux_system.h`
  - Increase `MAXIMUM_DISPLAYS` from `8` to `32`.
- `base/sources/backends/vulkan_gpu.c`
  - Read/store `minUniformBufferOffsetAlignment`.
  - Add guard rails before binding constant buffer descriptors.
- `base/sources/iron_gpu.c`
  - Align constant-buffer stride to backend-required uniform buffer alignment.
- `base/sources/iron_gpu.h`
  - Expose `gpu_uniform_buffer_align()`.

## Validation
- Local compile check (same as CI workflow command):
  - `cd paint && ../base/make --compile` ✅

## Issue
Fixes #1971
