### PR TITLE
Fix: Add locale-independent number parsing for all input methods (#2082)

### DIFF
--- a/base/sources/iron.h
+++ b/base/sources/iron.h
@@ -522,7 +522,10 @@ i32 parse_int_hex(const char *s) {
 #endif
 
 f32 parse_float(const char *s) {
-	return strtof(s, NULL);
+	// Replace comma with dot for locale-independent parsing
+	char *s_copy = string_replace_all(s, ",", ".");
+	f32 result = strtof(s_copy, NULL);
+	return result;
 }
 
 i32 color_from_floats(f32 r, f32 g, f32 b, f32 a) {

--- a/base/sources/iron.h
+++ b/base/sources/iron.h
@@ -524,7 +524,10 @@ i32 parse_int_hex(const char *s) {
 #endif
 
 f32 parse_float(const char *s) {
-	return strtof(s, NULL);
+	// Replace comma with dot for locale-independent parsing
+	char *s_copy = string_replace_all(s, ",", ".");
+	f32 result = strtof(s_copy, NULL);
+	return result;
 }
 
 i32 color_from_floats(f32 r, f32 g, f32 b, f32 a) {

--- a/base/sources/iron_json.c
+++ b/base/sources/iron_json.c
@@ -132,7 +132,7 @@ static int token_size() {
 
 static bool has_dot(char *str, uint32_t len) {
 	for (uint32_t i = 0; i < len; ++i) {
-		if (str[i] == '.') {
+		if (str[i] == '.' || str[i] == ',') {
 			return true;
 		}
 	}
@@ -162,11 +162,16 @@ static void token_write() {
 			store_ptr_abs(NULL);
 		}
 		else {
-			has_dot(source + t.start, t.end - t.start) ? store_f32(strtof(source + t.start, NULL)) :
+			// Replace comma with dot for locale-independent parsing
+			char *num_str = string_copy(source + t.start);
+			for (int i = 0; i < (t.end - t.start); i++) {
+				if (num_str[i] == ',') num_str[i] = '.';
+			}
+			has_dot(source + t.start, t.end - t.start) ? store_f32(strtof(num_str, NULL)) :
 #ifdef _WIN32
-			                                           store_i32(_strtoi64(source + t.start, NULL, 10));
+			                                           store_i32(_strtoi64(num_str, NULL, 10));
 #else
-			                                           store_i32(strtol(source + t.start, NULL, 10));
+			                                           store_i32(strtol(num_str, NULL, 10));
 #endif
 		}
 	}
@@ -452,7 +457,7 @@ static uint8_t    jenc_forced_array_type;
 
 static bool jenc_has_dot(int start, int end) {
 	for (int i = start; i < end; i++) {
-		if (jenc_src[i] == '.')
+		if (jenc_src[i] == '.' || jenc_src[i] == ',')
 			return true;
 	}
 	return false;
@@ -567,7 +572,12 @@ static void jenc_array(int count) {
 		armpack_write_u8(0xca);
 		for (int i = 0; i < count; i++) {
 			jsmntok_t t = jenc_tokens[jenc_ti++];
-			armpack_write_f32(strtof(jenc_src + t.start, NULL));
+			// Replace comma with dot for locale-independent parsing
+			char *num_str = string_copy(jenc_src + t.start);
+			for (int j = 0; j < (t.end - t.start); j++) {
+				if (num_str[j] == ',') num_str[j] = '.';
+			}
+			armpack_write_f32(strtof(num_str, NULL));
 		}
 	}
 	else if (elem_type == 0xd2) { // typed i32
@@ -637,7 +647,12 @@ static void jenc_value() {
 	}
 	else if (jenc_has_dot(t.start, t.end)) {
 		armpack_write_u8(0xca);
-		armpack_write_f32(strtof(jenc_src + t.start, NULL));
+		// Replace comma with dot for locale-independent parsing
+		char *num_str = string_copy(jenc_src + t.start);
+		for (int j = 0; j < (t.end - t.start); j++) {
+			if (num_str[j] == ',') num_str[j] = '.';
+		}
+		armpack_write_f32(strtof(num_str, NULL));
 	}
 	else {
 		armpack_write_u8(0xd2);

--- a/base/sources/iron_json.c
+++ b/base/sources/iron_json.c
@@ -147,7 +147,7 @@ static int token_size() {
 
 static bool has_dot(char *str, uint32_t len) {
 	for (uint32_t i = 0; i < len; ++i) {
-		if (str[i] == '.') {
+		if (str[i] == '.' || str[i] == ',') {
 			return true;
 		}
 	}
@@ -177,11 +177,16 @@ static void token_write() {
 			store_ptr_abs(NULL);
 		}
 		else {
-			has_dot(source + t.start, t.end - t.start) ? store_f32(strtof(source + t.start, NULL)) :
+			// Replace comma with dot for locale-independent parsing
+			char *num_str = string_copy(source + t.start);
+			for (int i = 0; i < (t.end - t.start); i++) {
+				if (num_str[i] == ',') num_str[i] = '.';
+			}
+			has_dot(source + t.start, t.end - t.start) ? store_f32(strtof(num_str, NULL)) :
 #ifdef _WIN32
-			                                           store_i32(_strtoi64(source + t.start, NULL, 10));
+			                                           store_i32(_strtoi64(num_str, NULL, 10));
 #else
-			                                           store_i32(strtol(source + t.start, NULL, 10));
+			                                           store_i32(strtol(num_str, NULL, 10));
 #endif
 		}
 	}
@@ -481,7 +486,7 @@ static uint8_t    jenc_forced_array_type;
 
 static bool jenc_has_dot(int start, int end) {
 	for (int i = start; i < end; i++) {
-		if (jenc_src[i] == '.')
+		if (jenc_src[i] == '.' || jenc_src[i] == ',')
 			return true;
 	}
 	return false;
@@ -596,7 +601,12 @@ static void jenc_array(int count) {
 		armpack_write_u8(0xca);
 		for (int i = 0; i < count; i++) {
 			jsmntok_t t = jenc_tokens[jenc_ti++];
-			armpack_write_f32(strtof(jenc_src + t.start, NULL));
+			// Replace comma with dot for locale-independent parsing
+			char *num_str = string_copy(jenc_src + t.start);
+			for (int j = 0; j < (t.end - t.start); j++) {
+				if (num_str[j] == ',') num_str[j] = '.';
+			}
+			armpack_write_f32(strtof(num_str, NULL));
 		}
 	}
 	else if (elem_type == 0xd2) { // typed i32
@@ -666,7 +676,12 @@ static void jenc_value() {
 	}
 	else if (jenc_has_dot(t.start, t.end)) {
 		armpack_write_u8(0xca);
-		armpack_write_f32(strtof(jenc_src + t.start, NULL));
+		// Replace comma with dot for locale-independent parsing
+		char *num_str = string_copy(jenc_src + t.start);
+		for (int j = 0; j < (t.end - t.start); j++) {
+			if (num_str[j] == ',') num_str[j] = '.';
+		}
+		armpack_write_f32(strtof(num_str, NULL));
 	}
 	else {
 		armpack_write_u8(0xd2);

--- a/base/sources/iron_ui.c
+++ b/base/sources/iron_ui.c
@@ -2311,11 +2311,15 @@ float ui_slider(ui_handle_t *handle, char *text, float from, float to, bool fill
 	if (current->submit_text_handle == handle) {
 		ui_submit_text_edit();
 #ifdef WITH_EVAL
-		minic_ctx_t *_ctx = minic_eval(string("float main() { return %s; }", handle->text));
+		// Replace comma with dot for locale-independent parsing
+		char *text_copy = string_replace_all(handle->text, ",", ".");
+		minic_ctx_t *_ctx = minic_eval(string("float main() { return %s; }", text_copy));
 		handle->f         = minic_ctx_result(_ctx);
 		minic_ctx_free(_ctx);
 #else
-		handle->f = atof(handle->text);
+		// Replace comma with dot for locale-independent parsing
+		char *text_copy = string_replace_all(handle->text, ",", ".");
+		handle->f = atof(text_copy);
 #endif
 		handle->changed = current->changed = true;
 	}

--- a/base/sources/iron_ui.c
+++ b/base/sources/iron_ui.c
@@ -2407,14 +2407,21 @@ float ui_slider(ui_handle_t *handle, char *text, float from, float to, bool fill
 	if (current->submit_text_handle == handle) {
 		ui_submit_text_edit();
 #ifdef WITH_EVAL
-		if (handle->text[0] == '.') {
-			handle->text = string("0%s", handle->text);
+		// Replace comma with dot for locale-independent parsing
+		char *text_copy = string_replace_all(handle->text, ",", ".");
+		if (text_copy[0] == '.') {
+			text_copy = string("0%s", text_copy);
 		}
-		minic_ctx_t *_ctx = minic_eval(string("float main() { return %s; }", handle->text));
+		minic_ctx_t *_ctx = minic_eval(string("float main() { return %s; }", text_copy));
 		handle->f         = minic_ctx_result(_ctx);
 		minic_ctx_free(_ctx);
 #else
-		handle->f = atof(handle->text);
+		// Replace comma with dot for locale-independent parsing
+		char *text_copy = string_replace_all(handle->text, ",", ".");
+		if (text_copy[0] == '.') {
+			text_copy = string("0%s", text_copy);
+		}
+		handle->f = atof(text_copy);
 #endif
 		handle->changed = current->changed = true;
 	}

--- a/base/sources/iron_ui_ext.c
+++ b/base/sources/iron_ui_ext.c
@@ -81,7 +81,9 @@ float ui_float_input(ui_handle_t *handle, char *label, int align, float precisio
 	handle->text = tmp;
 	sprintf(handle->text, "%f", round(handle->f * precision) / precision);
 	char *text = ui_text_input(handle, label, align, true, false);
-	handle->f  = atof(text);
+	// Replace comma with dot for locale-independent parsing
+	char *text_copy = string_replace_all(text, ",", ".");
+	handle->f  = atof(text_copy);
 	return handle->f;
 }
 

--- a/base/sources/iron_ui_ext.c
+++ b/base/sources/iron_ui_ext.c
@@ -82,7 +82,9 @@ float ui_float_input(ui_handle_t *handle, char *label, int align, float precisio
 	handle->text = tmp;
 	sprintf(handle->text, "%f", round(handle->f * precision) / precision);
 	char *text = ui_text_input(handle, label, align, true, false);
-	handle->f  = atof(text);
+	// Replace comma with dot for locale-independent parsing
+	char *text_copy = string_replace_all(text, ",", ".");
+	handle->f  = atof(text_copy);
 	return handle->f;
 }
 

--- a/base/sources/libs/minic.c
+++ b/base/sources/libs/minic.c
@@ -243,6 +243,21 @@ static void minic_lex_next(minic_lexer_t *l) {
 			return;
 		}
 
+		if (c == '.' && isdigit((unsigned char)l->src[l->pos])) {
+			double n    = 0;
+			double frac = 0.1;
+			while (isdigit((unsigned char)l->src[l->pos])) {
+				n += (l->src[l->pos++] - '0') * frac;
+				frac *= 0.1;
+			}
+			if (l->src[l->pos] == 'f' || l->src[l->pos] == 'F') {
+				l->pos++;
+			}
+			l->cur.val  = minic_val_float((float)n);
+			l->cur.type = TOK_NUMBER;
+			return;
+		}
+
 		for (size_t k = 0; k < sizeof(minic_ops) / sizeof(minic_ops[0]); ++k) {
 			if (c == minic_ops[k].a && (minic_ops[k].b == 0 || l->src[l->pos + 1] == minic_ops[k].b)) {
 				l->pos += minic_ops[k].b != 0 ? 2 : 1;

--- a/base/sources/libs/minic.c
+++ b/base/sources/libs/minic.c
@@ -260,6 +260,22 @@ static void minic_lex_next(minic_lexer_t *l) {
 			return;
 		}
 
+		if (c == '.' && isdigit((unsigned char)l->src[l->pos + 1])) {
+			l->pos++; // skip dot
+			double n    = 0;
+			double frac = 0.1;
+			while (isdigit((unsigned char)l->src[l->pos])) {
+				n += (l->src[l->pos++] - '0') * frac;
+				frac *= 0.1;
+			}
+			if (l->src[l->pos] == 'f' || l->src[l->pos] == 'F') {
+				l->pos++;
+			}
+			l->cur.val  = minic_val_float((float)n);
+			l->cur.type = TOK_NUMBER;
+			return;
+		}
+
 		for (size_t k = 0; k < sizeof(minic_ops3) / sizeof(minic_ops3[0]); ++k) {
 			if (c == minic_ops3[k].a && l->src[l->pos + 1] == minic_ops3[k].b && l->src[l->pos + 2] == minic_ops3[k].c) {
 				l->pos += 3;

--- a/base/sources/libs/minic_tests.c
+++ b/base/sources/libs/minic_tests.c
@@ -189,6 +189,18 @@ const char *test12 = " \n\
     } \n\
 ";
 
+// Test for leading-dot float literals (.3, .5f)
+const char *test13 = " \n\
+    float main() { \n\
+        float a = .3; \n\
+        float b = .5f; \n\
+        float c = 0.0; \n\
+        c = .7; \n\
+        if (a == 0.3 && b == 0.5 && c == 0.7) { return 0.0; } \n\
+        return 1.0; \n\
+    } \n\
+";
+
 #define MINIC_TEST(n, src)                                                            \
 	do {                                                                              \
 		minic_ctx_t *_c = minic_eval(src);                                            \
@@ -216,6 +228,7 @@ void minic_tests() {
 	MINIC_TEST(10, test10);
 	MINIC_TEST(11, test11);
 	MINIC_TEST(12, test12);
+	MINIC_TEST(13, test13);
 }
 
 #endif

--- a/base/sources/libs/minic_tests.c
+++ b/base/sources/libs/minic_tests.c
@@ -189,6 +189,18 @@ const char *test12 = " \n\
     } \n\
 ";
 
+// Test for leading-dot float literals (.3, .5f)
+const char *test13 = " \n\
+    float main() { \n\
+        float a = .3; \n\
+        float b = .5f; \n\
+        float c = 0.0; \n\
+        c = .7; \n\
+        if (a == 0.3 && b == 0.5 && c == 0.7) { return 0.0; } \n\
+        return 1.0; \n\
+    } \n\
+";
+
 #define MINIC_TEST(n, src)                                                            \
 	do {                                                                              \
 		minic_ctx_t *_c = minic_eval(src);                                            \
@@ -225,6 +237,7 @@ void minic_tests() {
 	MINIC_TEST(10, test10);
 	MINIC_TEST(11, test11);
 	MINIC_TEST(12, test12);
+	MINIC_TEST(13, test13);
 }
 
 #endif

--- a/paint/sources/nodes_brush/brush_output_node.c
+++ b/paint/sources/nodes_brush/brush_output_node.c
@@ -56,7 +56,7 @@ void brush_output_node_parse_inputs() {
 		}
 	}
 	else {
-		g_context->brush_nodes_opacity = opac->_f32;
+		g_context->brush_nodes_opacity = math_max(0.0, math_min(1.0, opac->_f32));
 		g_context->brush_mask_image    = NULL;
 	}
 

--- a/paint/sources/ui/tab_layers.c
+++ b/paint/sources/ui/tab_layers.c
@@ -705,6 +705,7 @@ void tab_layers_draw_layer_context_menu_draw() {
 	ui_handle_t *layer_opac_handle = ui_nest(ui_handle(__ID__), l->id);
 	layer_opac_handle->f           = l->mask_opacity;
 	ui_slider(layer_opac_handle, tr("Opacity"), 0.0, 1.0, true, 100.0, true, UI_ALIGN_RIGHT, true);
+	layer_opac_handle->f = math_max(0.0, math_min(1.0, layer_opac_handle->f));
 	if (layer_opac_handle->changed) {
 		if (g_ui->input_started) {
 			history_layer_opacity();

--- a/paint/sources/ui/tab_layers.c
+++ b/paint/sources/ui/tab_layers.c
@@ -727,6 +727,7 @@ void tab_layers_draw_layer_context_menu_draw() {
 	ui_handle_t *layer_opac_handle = ui_nest(ui_handle(__ID__), l->id);
 	layer_opac_handle->f           = l->mask_opacity;
 	ui_slider(layer_opac_handle, tr("Opacity"), 0.0, 1.0, true, 100.0, true, UI_ALIGN_RIGHT, true);
+	layer_opac_handle->f = math_max(0.0, math_min(1.0, layer_opac_handle->f));
 	if (layer_opac_handle->changed) {
 		if (g_ui->input_started) {
 			history_layer_opacity();

--- a/paint/sources/ui/tab_swatches.c
+++ b/paint/sources/ui/tab_swatches.c
@@ -76,6 +76,7 @@ void tab_swatches_draw_edit_menu() {
 	ui_handle_t *hopacity      = ui_handle(__ID__);
 	hopacity->f                = g_context->swatch->opacity;
 	g_context->swatch->opacity = ui_slider(hopacity, "Opacity", 0, 1, true, 100.0, true, UI_ALIGN_RIGHT, true);
+	g_context->swatch->opacity = math_max(0.0, math_min(1.0, g_context->swatch->opacity));
 
 	if (g_config->workflow == WORKFLOW_PBR) {
 		ui_handle_t *hocclusion      = ui_handle(__ID__);

--- a/paint/sources/ui/tab_swatches.c
+++ b/paint/sources/ui/tab_swatches.c
@@ -89,6 +89,7 @@ void tab_swatches_draw_edit_menu() {
 	ui_handle_t *hopacity      = ui_handle(__ID__);
 	hopacity->f                = g_context->swatch->opacity;
 	g_context->swatch->opacity = ui_slider(hopacity, "Opacity", 0, 1, true, 100.0, true, UI_ALIGN_RIGHT, true);
+	g_context->swatch->opacity = math_max(0.0, math_min(1.0, g_context->swatch->opacity));
 
 	if (g_config->workflow == WORKFLOW_PBR) {
 		ui_handle_t *hocclusion      = ui_handle(__ID__);

--- a/paint/sources/ui/ui_header.c
+++ b/paint/sources/ui/ui_header.c
@@ -273,6 +273,7 @@ void ui_header_draw_tool_properties() {
 		ui_handle_t *hopac               = ui_handle(__ID__);
 		hopac->f                         = g_context->picked_color->opacity;
 		g_context->picked_color->opacity = ui_slider(hopac, tr("Opacity"), 0.0, 1.0, true, 100.0, true, UI_ALIGN_RIGHT, true);
+		g_context->picked_color->opacity = math_max(0.0, math_min(1.0, g_context->picked_color->opacity));
 
 		ui_handle_t *h_select_mat         = ui_handle(__ID__);
 		h_select_mat->b                   = g_context->picker_select_material;
@@ -369,6 +370,7 @@ void ui_header_draw_tool_properties() {
 		ui_handle_t *brush_opacity_handle = ui_handle(__ID__);
 		brush_opacity_handle->f           = g_context->brush_opacity;
 		g_context->brush_opacity          = ui_slider(brush_opacity_handle, tr("Opacity"), 0.0, 1.0, true, 100.0, true, UI_ALIGN_RIGHT, true);
+		g_context->brush_opacity          = math_max(0.0, math_min(1.0, g_context->brush_opacity));
 		if (g_ui->is_hovered) {
 			any_map_t *vars = any_map_create();
 			any_map_set(vars, "brush_opacity", any_map_get(g_keymap, "brush_opacity"));

--- a/paint/sources/ui/ui_header.c
+++ b/paint/sources/ui/ui_header.c
@@ -271,6 +271,7 @@ void ui_header_draw_tool_properties() {
 		ui_handle_t *hopac               = ui_handle(__ID__);
 		hopac->f                         = g_context->picked_color->opacity;
 		g_context->picked_color->opacity = ui_slider(hopac, tr("Opacity"), 0.0, 1.0, true, 100.0, true, UI_ALIGN_RIGHT, true);
+		g_context->picked_color->opacity = math_max(0.0, math_min(1.0, g_context->picked_color->opacity));
 
 		ui_handle_t *h_select_mat         = ui_handle(__ID__);
 		h_select_mat->b                   = g_context->picker_select_material;
@@ -377,6 +378,7 @@ void ui_header_draw_tool_properties() {
 		ui_handle_t *brush_opacity_handle = ui_handle(__ID__);
 		brush_opacity_handle->f           = g_context->brush_opacity;
 		g_context->brush_opacity          = ui_slider(brush_opacity_handle, tr("Opacity"), 0.0, 1.0, true, 100.0, true, UI_ALIGN_RIGHT, true);
+		g_context->brush_opacity          = math_max(0.0, math_min(1.0, g_context->brush_opacity));
 		if (g_ui->is_hovered) {
 			any_map_t *vars = any_map_create();
 			any_map_set(vars, "brush_opacity", any_map_get(g_keymap, "brush_opacity"));

--- a/paint/sources/uniforms.c
+++ b/paint/sources/uniforms.c
@@ -63,7 +63,7 @@ f32 uniforms_ext_f32_link(object_t *object, material_data_t *mat, char *link) {
 		if (g_config->pressure_opacity && pen_down("tip") && !slot_layer_is_path(g_context->layer)) {
 			val *= pen_pressure * g_config->pressure_sensitivity;
 		}
-		return val;
+		return math_max(0.0, math_min(1.0, val));
 	}
 	else if (string_equals(link, "_brush_hardness")) {
 		bool decal_mask = context_is_decal_mask_paint();

--- a/paint/sources/uniforms.c
+++ b/paint/sources/uniforms.c
@@ -69,7 +69,7 @@ f32 uniforms_ext_f32_link(object_t *object, shader_data_t *mat, char *link) {
 		if (g_config->pressure_opacity && (pen_down("tip") || pen_released("tip")) && !slot_layer_is_path(g_context->layer)) {
 			val *= pen_pressure * g_config->pressure_sensitivity;
 		}
-		return val;
+		return math_max(0.0, math_min(1.0, val));
 	}
 	else if (string_equals(link, "_brush_hardness")) {
 		bool decal_mask = context_is_decal_mask_paint_pass();


### PR DESCRIPTION
This PR fixes issue #2082 and #2084.

## #2082: Locale-independent float parsing
When users enter comma-separated decimal values (e.g., "1,5") in locales where comma is the decimal separator, the application incorrectly parses these values, leading to:
- Negative UI scale values (-1) that crash the application
- Incorrect brush radius values
- General float parsing failures across the UI

### Solution
Replace commas with dots before parsing floats in all input methods:

**Modified files:**
1. **base/sources/iron.h** - `parse_float()` function
2. **base/sources/iron_ui.c** - `ui_slider()` function (both WITH_EVAL and non-WITH_EVAL paths)
3. **base/sources/iron_ui_ext.c** - `ui_float_input()` function
4. **base/sources/iron_json.c** - JSON parsing (3 locations)
5. **base/sources/libs/minic.c** - Lexer now recognizes leading-dot float literals (`.3`, `.5f`)
6. **base/sources/libs/minic_tests.c** - Added test13 for leading-dot float literals

## #2084: Clamp opacity to [0,1] range
Opacity values could drift outside the valid [0,1] range through the UI and rendering pipeline, causing visual artifacts.

### Solution
Clamp opacity after slider input and in uniform reads:

**Modified files:**
- `paint/sources/nodes_brush/brush_output_node.c`
- `paint/sources/ui/tab_layers.c`
- `paint/sources/ui/tab_swatches.c`
- `paint/sources/ui/ui_header.c`
- `paint/sources/uniforms.c`

## Testing
- All comma-to-dot and leading-dot float cases verified with standalone test
- Full ArmorPaint Debug x64 build compiles cleanly
- Manual testing confirmed comma-separated values and opacity sliders work correctly