### PR TITLE
Fix priority crash, import, export, history and opacity paths

### DIFF
--- a/docs/superpowers/plans/2026-07-17-armorpaint-priority-fixes.md
+++ b/docs/superpowers/plans/2026-07-17-armorpaint-priority-fixes.md
@@ -1,0 +1,34 @@
+# ArmorPaint Priority Issue Fixes Implementation Plan
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the selected high-priority ArmorPaint issues with evidence-backed, low-risk guards and behavior fixes, then publish the work as a draft pull request.
+
+**Architecture:** Keep fixes at the existing boundary where invalid persisted configuration, missing external assets, missing GPU textures, layer-limit failures, and history traversal are first observable. Avoid broad refactors or platform-specific workarounds that cannot be validated locally.
+
+**Tech Stack:** C, ArmorPaint/Iron runtime, generated Visual Studio project files, PowerShell, Python source-regression checks, GitHub CLI/API.
+
+## Global Constraints
+
+- Preserve unrelated upstream changes and keep the branch narrowly scoped.
+- Cover selected issues #2082, #2080, #2065, #2090, #792, #2052, #2062, and #2084 where the repository provides a defensible fix.
+- Add only a small number of adjacent, clearly proven crash guards (especially failed layer creation and missing export presets/assets).
+- Run tests before and after each implementation group where the local toolchain permits; document the missing native compiler if it remains unavailable.
+- Do not claim Linux/GPU-specific reproduction when only static call-chain evidence is available.
+
+## Tasks
+
+- [ ] Add failing source-regression checks for configuration validation, opacity clamping, import/export null guards, 2D texture safety, layer creation limits, and bounded history traversal.
+- [ ] Harden UI-scale loading/saving/application so malformed or negative persisted values cannot prevent startup.
+- [ ] Clamp brush opacity after pressure/node multipliers before it reaches paint and cursor rendering.
+- [ ] Make Blender import use a writable temporary path and stop cleanly when Blender does not produce the OBJ.
+- [ ] Make packed-project/export paths reject missing assets/presets instead of dereferencing null data.
+- [ ] Make 2D view tolerate layers without initialized paint textures and make layer creation failure-safe at the maximum layer count.
+- [ ] Group layer-mask undo restoration for a delete operation and bound redo history scanning to prevent out-of-range access.
+- [ ] Run regression checks, regenerate the ArmorPaint project, inspect the diff, commit the focused changes, push the branch, and open a draft PR.
+
+## Verification Checklist
+
+- [ ] Regression checks pass after the fixes.
+- [ ] `base/make.bat --help` (project generation path used by this checkout) completes successfully.
+- [ ] Native compilation or launch is attempted; any unavailable compiler/runtime limitation is recorded in the PR.
+- [ ] Branch status, commit, remote branch, and draft PR are all verified directly.

--- a/docs/superpowers/plans/2026-07-17-armorpaint-priority-fixes.md
+++ b/docs/superpowers/plans/2026-07-17-armorpaint-priority-fixes.md
@@ -17,18 +17,18 @@
 
 ## Tasks
 
-- [ ] Add failing source-regression checks for configuration validation, opacity clamping, import/export null guards, 2D texture safety, layer creation limits, and bounded history traversal.
-- [ ] Harden UI-scale loading/saving/application so malformed or negative persisted values cannot prevent startup.
-- [ ] Clamp brush opacity after pressure/node multipliers before it reaches paint and cursor rendering.
-- [ ] Make Blender import use a writable temporary path and stop cleanly when Blender does not produce the OBJ.
-- [ ] Make packed-project/export paths reject missing assets/presets instead of dereferencing null data.
-- [ ] Make 2D view tolerate layers without initialized paint textures and make layer creation failure-safe at the maximum layer count.
-- [ ] Group layer-mask undo restoration for a delete operation and bound redo history scanning to prevent out-of-range access.
-- [ ] Run regression checks, regenerate the ArmorPaint project, inspect the diff, commit the focused changes, push the branch, and open a draft PR.
+- [x] Add failing source-regression checks for configuration validation, opacity clamping, import/export null guards, 2D texture safety, layer creation limits, and bounded history traversal.
+- [x] Harden UI-scale loading/saving/application so malformed or negative persisted values cannot prevent startup.
+- [x] Clamp brush opacity after pressure/node multipliers before it reaches paint and cursor rendering.
+- [x] Make Blender import use a writable temporary path and stop cleanly when Blender does not produce the OBJ.
+- [x] Make packed-project/export paths reject missing assets/presets instead of dereferencing null data.
+- [x] Make 2D view tolerate layers without initialized paint textures and make layer creation failure-safe at the maximum layer count.
+- [x] Group layer-mask undo restoration for a delete operation and bound redo history scanning to prevent out-of-range access.
+- [x] Run regression checks, regenerate the ArmorPaint project, inspect the diff, commit the focused changes, push the branch, and open a draft PR.
 
 ## Verification Checklist
 
-- [ ] Regression checks pass after the fixes.
-- [ ] `base/make.bat --help` (project generation path used by this checkout) completes successfully.
-- [ ] Native compilation or launch is attempted; any unavailable compiler/runtime limitation is recorded in the PR.
-- [ ] Branch status, commit, remote branch, and draft PR are all verified directly.
+- [x] Regression checks pass after the fixes.
+- [x] `base/make.bat --help` (project generation path used by this checkout) completes successfully.
+- [x] Native compilation or launch is attempted; any unavailable compiler/runtime limitation is recorded in the PR.
+- [x] Branch status, commit, remote branch, and draft PR are all verified directly.

--- a/paint/sources/config.c
+++ b/paint/sources/config.c
@@ -8,6 +8,15 @@ typedef struct version {
 
 bool config_loaded = false;
 
+f32 config_validate_window_scale(f32 scale) {
+	// The UI slider accepts values from 1 to 4. Keep malformed values from
+	// entering layout calculations when a config file was edited externally.
+	if (!(scale >= 1.0 && scale <= 4.0)) {
+		return 1.0;
+	}
+	return scale;
+}
+
 void config_load() {
 	char *path = "";
 	if (path_is_protected()) {
@@ -36,6 +45,7 @@ void config_load() {
 			gc_unroot(g_config);
 			g_config = json_parse(config_string);
 			gc_root(g_config);
+			g_config->window_scale = config_validate_window_scale(g_config->window_scale);
 		}
 	}
 }
@@ -44,6 +54,7 @@ void config_save() {
 	if (g_config->workspace == WORKSPACE_PLAYER) {
 		return;
 	}
+	g_config->window_scale = config_validate_window_scale(g_config->window_scale);
 
 	// Use system application data folder
 	// when running from protected path like "Program Files"
@@ -395,6 +406,7 @@ void config_import_from(config_t *from) {
 	gc_root(g_config);
 	g_config->sha     = string_copy(_sha);
 	g_config->version = string_copy(_version);
+	g_config->window_scale = config_validate_window_scale(g_config->window_scale);
 	gc_unroot(ui_children);
 	ui_children = any_map_create(); // Reset ui handles
 	gc_root(ui_children);

--- a/paint/sources/functions.h
+++ b/paint/sources/functions.h
@@ -96,6 +96,7 @@ void                      render_envsphere();
 void                      render_pathsphere();
 void                      config_load();
 void                      config_save();
+f32                       config_validate_window_scale(f32 scale);
 void                      config_init();
 void                      config_init_layout();
 char                     *config_get_sha();
@@ -290,7 +291,7 @@ void                      export_arm_run_mesh(char *path, mesh_object_t_array_t 
 void                      export_arm_run_project();
 void                      export_arm_run_material(char *path);
 void                      export_arm_run_brush(char *path);
-void                      export_arm_pack_assets(project_t *raw, asset_t_array_t *assets);
+bool                      export_arm_pack_assets(project_t *raw, asset_t_array_t *assets);
 void                      export_arm_run_swatches(char *path);
 void                      import_asset_run(char *path, f32 drop_x, f32 drop_y, bool show_box, bool hdr_as_envmap, void (*done)(void));
 void                      make_particle_mask(node_shader_t *kong);

--- a/paint/sources/history.c
+++ b/paint/sources/history.c
@@ -66,12 +66,26 @@ void history_undo_delete_layer_group(void *_) {
 	i32 active = history_steps->length - 1 - history_redos;
 	// 1. Undo deleting group masks
 	i32 n = 1;
-	while (history_steps->buffer[active - n]->layer_type == LAYER_SLOT_TYPE_MASK) {
+	while (active - n >= 0 && history_steps->buffer[active - n]->layer_type == LAYER_SLOT_TYPE_MASK) {
 		history_undo();
 		++n;
 	}
 	// 2. Undo a mask to have a non empty group
 	history_undo();
+}
+
+void history_undo_delete_layer_masks(void *_) {
+	while (true) {
+		i32 active = history_steps->length - 1 - history_redos;
+		if (active < 0) {
+			return;
+		}
+		history_step_t *step = history_steps->buffer[active];
+		if (step->action != HISTORY_ACTION_DELETE_LAYER || step->layer_type != LAYER_SLOT_TYPE_MASK) {
+			return;
+		}
+		history_undo();
+	}
 }
 
 ui_node_canvas_t *history_get_canvas(history_step_t *step) {
@@ -150,6 +164,11 @@ void history_undo() {
 			// Undo at least second time in order to avoid empty groups
 			if (step->layer_type == LAYER_SLOT_TYPE_GROUP) {
 				sys_notify_on_next_frame(&history_undo_delete_layer_group, NULL);
+			}
+			else if (step->layer_type == LAYER_SLOT_TYPE_LAYER && active > 0 &&
+			         history_steps->buffer[active - 1]->action == HISTORY_ACTION_DELETE_LAYER &&
+			         history_steps->buffer[active - 1]->layer_type == LAYER_SLOT_TYPE_MASK) {
+				sys_notify_on_next_frame(&history_undo_delete_layer_masks, NULL);
 			}
 		}
 		else if (step->action == HISTORY_ACTION_CLEAR_LAYER) {
@@ -409,7 +428,7 @@ void history_redo_duplicate_layer(void *_) {
 void history_redo_delete_layer(void *_) {
 	i32 active = history_steps->length - history_redos;
 	i32 n      = 1;
-	while (history_steps->buffer[active + n]->layer_type == LAYER_SLOT_TYPE_MASK) {
+	while (active + n < history_steps->length && history_steps->buffer[active + n]->layer_type == LAYER_SLOT_TYPE_MASK) {
 		++n;
 	}
 	for (i32 i = 0; i < n; ++i) {

--- a/paint/sources/io/export_arm.c
+++ b/paint/sources/io/export_arm.c
@@ -339,7 +339,10 @@ void export_arm_run_project() {
 #endif
 
 	if (g_context->pack_assets_on_save) { // Pack textures
-		export_arm_pack_assets(g_project, g_project->_->assets);
+		if (!export_arm_pack_assets(g_project, g_project->_->assets)) {
+			console_error(tr("Error: Could not pack project assets"));
+			return;
+		}
 	}
 
 	buffer_t *buffer = util_encode_project(g_project);
@@ -468,7 +471,10 @@ void export_arm_run_material(char *path) {
 	}
 
 	if (g_context->pack_assets_on_export) { // Pack textures
-		export_arm_pack_assets(raw, assets);
+		if (!export_arm_pack_assets(raw, assets)) {
+			console_error(tr("Error: Could not pack material assets"));
+			return;
+		}
 	}
 
 	buffer_t *buffer = util_encode_project(raw);
@@ -520,27 +526,45 @@ void export_arm_run_brush(char *path) {
 	}
 
 	if (g_context->pack_assets_on_export) { // Pack textures
-		export_arm_pack_assets(raw, assets);
+		if (!export_arm_pack_assets(raw, assets)) {
+			console_error(tr("Error: Could not pack brush assets"));
+			return;
+		}
 	}
 
 	buffer_t *buffer = util_encode_project(raw);
 	iron_file_save_bytes(path, buffer, buffer->length + 1);
 }
 
-void export_arm_pack_assets(project_t *raw, asset_t_array_t *assets) {
+bool export_arm_pack_assets(project_t *raw, asset_t_array_t *assets) {
+	if (raw == NULL || assets == NULL) {
+		return raw != NULL;
+	}
 	if (raw->packed_assets == NULL) {
 		raw->packed_assets = any_array_create_from_raw((void *[]){}, 0);
 	}
+	bool                  success     = true;
 	gpu_texture_t_array_t *temp_images = any_array_create_from_raw((void *[]){}, 0);
 	for (i32 i = 0; i < assets->length; ++i) {
-		if (!project_packed_asset_exists(raw->packed_assets, assets->buffer[i]->file)) {
-			gpu_texture_t *image = project_get_image(assets->buffer[i]);
+		asset_t *asset = assets->buffer[i];
+		if (asset == NULL || asset->file == NULL || string_equals(asset->file, "")) {
+			console_error(tr("Error: Invalid texture asset"));
+			success = false;
+			continue;
+		}
+		if (!project_packed_asset_exists(raw->packed_assets, asset->file)) {
+			gpu_texture_t *image = project_get_image(asset);
+			if (image == NULL) {
+				console_error(tr("Error: Texture asset is not loaded"));
+				success = false;
+				continue;
+			}
 			gpu_texture_t *temp  = gpu_create_render_target(image->width, image->height, GPU_TEXTURE_FORMAT_RGBA32);
 			draw_begin(temp, false, 0);
 			draw_image(image, 0, 0);
 			draw_end();
 			any_array_push(temp_images, temp);
-			packed_asset_t *pa = GC_ALLOC_INIT(packed_asset_t, {.name  = assets->buffer[i]->file,
+			packed_asset_t *pa = GC_ALLOC_INIT(packed_asset_t, {.name  = asset->file,
 			                                                    .bytes = ends_with(assets->buffer[i]->file, ".jpg")
 			                                                                 ? iron_encode_jpg(gpu_get_texture_pixels(temp), temp->width, temp->height, 0, 80)
 			                                                                 : iron_encode_png(gpu_get_texture_pixels(temp), temp->width, temp->height, 0)});
@@ -552,6 +576,7 @@ void export_arm_pack_assets(project_t *raw, asset_t_array_t *assets) {
 		gpu_texture_t *image = temp_images->buffer[i];
 		gpu_delete_texture(image);
 	}
+	return success;
 }
 
 void export_arm_run_swatches(char *path) {

--- a/paint/sources/io/export_texture.c
+++ b/paint/sources/io/export_texture.c
@@ -47,7 +47,9 @@ static void export_texture_write_texture(char *file, buffer_t *pixels, i32 type,
 		        asset,
 		    },
 		    1);
-		export_arm_pack_assets(g_project, assets);
+		if (!export_arm_pack_assets(g_project, assets)) {
+			console_error(tr("Error: Could not pack exported texture"));
+		}
 		return;
 	}
 
@@ -145,6 +147,10 @@ static void export_texture_set_channel(i32 value, buffer_t *to, i32 to_channel, 
 }
 
 static void export_texture_run_layers(char *path, slot_layer_t_array_t *layers, char *object_name, bool bake_material) {
+	if (layers == NULL || layers->length == 0 || layers->buffer[0] == NULL || layers->buffer[0]->texpaint == NULL) {
+		console_error(tr("Error: No paint layer available for texture export"));
+		return;
+	}
 	i32 texture_size_x = config_get_texture_res_x();
 	i32 texture_size_y = config_get_texture_res_y();
 #if defined(IRON_ANDROID) || defined(IRON_IOS)
@@ -494,7 +500,13 @@ void export_texture_run(char *path, bool bake_material) {
 	////
 	if (box_export_files == NULL) {
 		box_export_fetch_presets();
+	}
+	if (box_export_preset == NULL) {
 		box_export_parse_preset();
+	}
+	if (box_export_preset == NULL || box_export_preset->textures == NULL) {
+		console_error(tr("Error: No valid export preset available"));
+		return;
 	}
 	////
 

--- a/paint/sources/io/import_blend_mesh.c
+++ b/paint/sources/io/import_blend_mesh.c
@@ -38,11 +38,12 @@ void import_blend_mesh_run(char *path, bool replace_existing) {
 		return;
 	}
 
-	char *save       = "tmp.obj";
-	char *bpy_folder = "data/";
-	if (path_is_protected()) {
-		save       = string("%s%s", iron_internal_save_path(), save);
-		bpy_folder = "";
+	// Blender must write the temporary OBJ to a user-writable location. The
+	// working directory can be read-only on Linux and in installed builds.
+	char *save       = string("%stmp.obj", iron_internal_save_path());
+	char *bpy_folder = "";
+	if (iron_file_exists(save)) {
+		iron_delete_file(save);
 	}
 
 	// Have to use ; instead of \n on windows
@@ -54,5 +55,9 @@ void import_blend_mesh_run(char *path, bool replace_existing) {
 	char *bl = string_replace_all(g_config->blender, " ", "\\ ");
 #endif
 	iron_sys_command(string("%s \"%s\" -b --python-expr \"%s\"", bl, path, py));
+	if (!iron_file_exists(save)) {
+		console_error(tr("Error: Blender did not create the temporary OBJ"));
+		return;
+	}
 	import_obj_run(save, replace_existing);
 }

--- a/paint/sources/render/make_sculpt.c
+++ b/paint/sources/render/make_sculpt.c
@@ -1020,6 +1020,9 @@ void sculpt_init() {
 
 void sculpt_layers_create_sculpt_layer() {
 	slot_layer_t *l = layers_new_layer(true, -1, NULL);
+	if (l == NULL) {
+		return;
+	}
 	l->name         = string("Sculpt %d", l->id + 1);
 	sculpt_init_meshes();
 	sculpt_init_sculpt_texture(l);

--- a/paint/sources/render/render_path_paint.c
+++ b/paint/sources/render/render_path_paint.c
@@ -704,6 +704,7 @@ void render_path_paint_draw_cursor_decal(f32 mx, f32 my, f32 radius, f32 opacity
 	gpu_set_float3(pipes_cursor_decal_camera_up, up.x, up.y, up.z);
 	gpu_set_float(pipes_cursor_decal_camera_align, context_is_brush_camera_align() ? 1.0f : 0.0f);
 	f32 opacity = g_context->brush_opacity * brush_nodes_opacity * opacity_scale;
+	opacity     = fminf(fmaxf(opacity, 0.0), 1.0);
 	gpu_set_float(pipes_cursor_decal_opacity, opacity);
 	f32 angle = (g_context->brush_angle + brush_nodes_angle) * (math_pi() / 180.0);
 	gpu_set_float2(pipes_cursor_decal_angle, math_cos(angle), math_sin(angle));

--- a/paint/sources/slot_layer.c
+++ b/paint/sources/slot_layer.c
@@ -475,6 +475,9 @@ void slot_layer_to_fill_layer_on_next_frame(void *_) {
 }
 
 void slot_layer_to_fill_layer(slot_layer_t *raw) {
+	if (raw == NULL || g_context->material == NULL) {
+		return;
+	}
 	context_set_layer(raw);
 	raw->fill_material = g_context->material;
 	layers_update_fill_layer(true);

--- a/paint/sources/ui/box_export.c
+++ b/paint/sources/ui/box_export.c
@@ -277,13 +277,35 @@ void box_export_tab_presets_new_box() {
 	}
 }
 
+void box_export_set_generic_preset() {
+	char *fallback = "{\"textures\":[{\"name\":\"base\",\"channels\":[\"base_r\",\"base_g\",\"base_b\",\"1.0\"],\"color_space\":\"linear\"}]}";
+	gc_unroot(box_export_preset);
+	box_export_preset = json_parse(fallback);
+	gc_root(box_export_preset);
+}
+
 void box_export_parse_preset() {
+	if (box_export_files == NULL || box_export_hpreset == NULL || box_export_files->length == 0 || box_export_hpreset->i < 0 ||
+	    box_export_hpreset->i >= box_export_files->length) {
+		console_error(tr("Error: No valid export preset found"));
+		box_export_set_generic_preset();
+		return;
+	}
 	char     *file = string("export_presets/%s.json", box_export_files->buffer[box_export_hpreset->i]);
 	buffer_t *blob = data_get_blob(file);
+	if (blob == NULL) {
+		console_error(tr("Error: Could not read export preset"));
+		box_export_set_generic_preset();
+		return;
+	}
 	gc_unroot(box_export_preset);
 	box_export_preset = json_parse(sys_buffer_to_string(blob));
 	gc_root(box_export_preset);
 	data_delete_blob(file);
+	if (box_export_preset == NULL || box_export_preset->textures == NULL) {
+		console_error(tr("Error: Invalid export preset"));
+		box_export_set_generic_preset();
+	}
 }
 
 void box_export_tab_presets() {

--- a/paint/sources/ui/box_preferences.c
+++ b/paint/sources/ui/box_preferences.c
@@ -9,7 +9,8 @@ ui_handle_t    *_box_preferences_h;
 i32             _box_preferences_i;
 
 void box_preferences_set_scale() {
-	f32 scale = g_config->window_scale;
+	g_config->window_scale = config_validate_window_scale(g_config->window_scale);
+	f32 scale             = g_config->window_scale;
 	ui_set_scale(scale);
 	ui_header_h                                    = math_floor(ui_header_default_h * scale);
 	g_config->layout->buffer[LAYOUT_SIZE_STATUS_H] = math_floor(ui_statusbar_default_h * scale);

--- a/paint/sources/ui/tab_layers.c
+++ b/paint/sources/ui/tab_layers.c
@@ -158,6 +158,12 @@ void tab_layers_draw_layer_slot_mini(slot_layer_t *l, i32 i) {
 }
 
 void tab_layers_delete_layer(slot_layer_t *l) {
+	if (l == NULL) {
+		return;
+	}
+	bool          l_is_mask        = slot_layer_is_mask(l);
+	slot_layer_t *l_parent        = l->parent;
+	slot_layer_t *l_group_parent  = slot_layer_is_in_group(l) ? slot_layer_get_containing_group(l) : NULL;
 	i32_map_t *pointers = tab_layers_init_layer_map();
 
 	if (slot_layer_is_layer(l) && slot_layer_has_masks(l, false)) {
@@ -200,14 +206,14 @@ void tab_layers_delete_layer(slot_layer_t *l) {
 	history_delete_layer();
 	slot_layer_delete(l);
 
-	if (slot_layer_is_mask(l)) {
-		g_context->layer = l->parent;
+	if (l_is_mask && l_parent != NULL) {
+		g_context->layer = l_parent;
 		layers_update_fill_layers();
 	}
 
 	// Remove empty group
-	if (slot_layer_is_in_group(l) && slot_layer_get_children(slot_layer_get_containing_group(l)) == NULL) {
-		slot_layer_t *g = slot_layer_get_containing_group(l);
+	if (l_group_parent != NULL && slot_layer_get_children(l_group_parent) == NULL) {
+		slot_layer_t *g = l_group_parent;
 		// Maybe some group masks are left
 		if (slot_layer_has_masks(g, true)) {
 			for (i32 i = 0; i < slot_layer_get_masks(g, true)->length; ++i) {
@@ -217,9 +223,9 @@ void tab_layers_delete_layer(slot_layer_t *l) {
 				slot_layer_delete(m);
 			}
 		}
-		g_context->layer = l->parent;
+		g_context->layer = l_parent != NULL ? l_parent : g;
 		history_delete_layer();
-		slot_layer_delete(l->parent);
+		slot_layer_delete(g);
 	}
 	g_context->ddirty = 2;
 	for (i32 i = 0; i < g_project->_->materials->length; ++i) {
@@ -1029,7 +1035,10 @@ void tab_layers_button_new_menu() {
 	}
 	else {
 		if (ui_menu_button(tr("Paint Layer"), "", ICON_PAINT)) {
-			layers_new_layer(true, -1, NULL);
+			slot_layer_t *new_layer = layers_new_layer(true, -1, NULL);
+			if (new_layer == NULL) {
+				return;
+			}
 			history_new_layer();
 		}
 	}
@@ -1040,11 +1049,15 @@ void tab_layers_button_new_menu() {
 		layers_create_fill_layer(UV_TYPE_PROJECT, mat4_nan(), -1);
 	}
 	if (ui_menu_button(tr("Path"), "", ICON_PATH)) {
-		layers_new_path_layer(false);
+		if (layers_new_path_layer(false) == NULL) {
+			return;
+		}
 		history_new_layer();
 	}
 	if (ui_menu_button(tr("Curve"), "", ICON_CURVE)) {
-		layers_new_path_layer(true);
+		if (layers_new_path_layer(true) == NULL) {
+			return;
+		}
 		history_new_layer();
 	}
 	if (ui_menu_button(tr("Black Mask"), "", ICON_MASK)) {
@@ -1055,6 +1068,9 @@ void tab_layers_button_new_menu() {
 
 		i32_map_t    *pointers = tab_layers_init_layer_map();
 		slot_layer_t *m        = layers_new_mask(false, l, -1);
+		if (m == NULL) {
+			return;
+		}
 		for (i32 i = 0; i < g_project->_->materials->length; ++i) {
 			slot_material_t *mat = g_project->_->materials->buffer[i];
 			tab_layers_remap_layer_pointers(mat->canvas->nodes, tab_layers_fill_layer_map(pointers));
@@ -1072,6 +1088,9 @@ void tab_layers_button_new_menu() {
 
 		i32_map_t    *pointers = tab_layers_init_layer_map();
 		slot_layer_t *m        = layers_new_mask(false, l, -1);
+		if (m == NULL) {
+			return;
+		}
 		for (i32 i = 0; i < g_project->_->materials->length; ++i) {
 			slot_material_t *mat = g_project->_->materials->buffer[i];
 			tab_layers_remap_layer_pointers(mat->canvas->nodes, tab_layers_fill_layer_map(pointers));
@@ -1089,6 +1108,9 @@ void tab_layers_button_new_menu() {
 
 		i32_map_t    *pointers = tab_layers_init_layer_map();
 		slot_layer_t *m        = layers_new_mask(false, l, -1);
+		if (m == NULL) {
+			return;
+		}
 		for (i32 i = 0; i < g_project->_->materials->length; ++i) {
 			slot_material_t *mat = g_project->_->materials->buffer[i];
 			tab_layers_remap_layer_pointers(mat->canvas->nodes, tab_layers_fill_layer_map(pointers));
@@ -1116,6 +1138,9 @@ void tab_layers_button_new_menu() {
 
 		i32_map_t    *pointers = tab_layers_init_layer_map();
 		slot_layer_t *group    = layers_new_group();
+		if (group == NULL) {
+			return;
+		}
 		context_set_layer(l);
 		array_remove(g_project->_->layers, group);
 		array_insert(g_project->_->layers, array_index_of(g_project->_->layers, l) + 1, group);

--- a/paint/sources/ui/ui_view2d.c
+++ b/paint/sources/ui/ui_view2d.c
@@ -225,22 +225,24 @@ void ui_view2d_update(void *_) {
 			if (g_config->touch_ui) {
 				// Paint only when clicking on the layer rect
 				slot_layer_t  *layer   = g_context->layer;
-				gpu_texture_t *tex     = layer->texpaint;
-				f32            ratio   = tex->height / (float)tex->width;
-				f32            wm      = fmin(ui_view2d_ww, ui_view2d_wh);
-				f32            tw      = wm * 0.9 * ui_view2d_pan_scale;
-				f32            th      = tw * ratio;
-				f32            tx      = ui_view2d_ww / 2.0 - tw / 2.0 + ui_view2d_pan_x;
-				i32            headerh = g_config->layout->buffer[LAYOUT_SIZE_HEADER] == 1 ? ui_header_h * 2 : ui_header_h;
-				i32            apph    = iron_window_height() - g_config->layout->buffer[LAYOUT_SIZE_STATUS_H] + headerh;
-				f32            ty      = apph / 2.0 - th / 2.0 + ui_view2d_pan_y;
-				f32            mx      = mouse_x - ui_view2d_wx;
-				f32            my      = mouse_y - ui_view2d_wy;
-				if (mx > tx && mx < tx + tw && my > ty && my < ty + th) {
-					ui_view2d_layer_touched = true;
-				}
-				if (ui_view2d_layer_touched) {
-					g_context->paint2d = true;
+				gpu_texture_t *tex     = layer == NULL ? NULL : layer->texpaint;
+				if (tex != NULL) {
+					f32 ratio   = tex->height / (float)tex->width;
+					f32 wm      = fmin(ui_view2d_ww, ui_view2d_wh);
+					f32 tw      = wm * 0.9 * ui_view2d_pan_scale;
+					f32 th      = tw * ratio;
+					f32 tx      = ui_view2d_ww / 2.0 - tw / 2.0 + ui_view2d_pan_x;
+					i32 headerh = g_config->layout->buffer[LAYOUT_SIZE_HEADER] == 1 ? ui_header_h * 2 : ui_header_h;
+					i32 apph    = iron_window_height() - g_config->layout->buffer[LAYOUT_SIZE_STATUS_H] + headerh;
+					f32 ty      = apph / 2.0 - th / 2.0 + ui_view2d_pan_y;
+					f32 mx      = mouse_x - ui_view2d_wx;
+					f32 my      = mouse_y - ui_view2d_wy;
+					if (mx > tx && mx < tx + tw && my > ty && my < ty + th) {
+						ui_view2d_layer_touched = true;
+					}
+					if (ui_view2d_layer_touched) {
+						g_context->paint2d = true;
+					}
 				}
 			}
 			else {

--- a/paint/sources/uniforms.c
+++ b/paint/sources/uniforms.c
@@ -69,7 +69,7 @@ f32 uniforms_ext_f32_link(object_t *object, material_data_t *mat, char *link) {
 		if (g_config->pressure_opacity && (pen_down("tip") || pen_released("tip")) && !slot_layer_is_path(g_context->layer)) {
 			val *= pen_pressure * g_config->pressure_sensitivity;
 		}
-		return val;
+		return fminf(fmaxf(val, 0.0), 1.0);
 	}
 	else if (string_equals(link, "_brush_hardness")) {
 		bool decal_mask = context_is_decal_mask_paint_pass();

--- a/paint/sources/util/util_layer.c
+++ b/paint/sources/util/util_layer.c
@@ -428,6 +428,9 @@ void layers_update_path_layers() {
 }
 
 void layers_update_fill_layer(bool parse_paint) {
+	if (g_context->layer == NULL || g_context->material == NULL) {
+		return;
+	}
 	gpu_texture_t *current = _draw_current;
 	bool           in_use  = gpu_in_use;
 	if (in_use)
@@ -577,11 +580,14 @@ void layers_new_layer_clear(slot_layer_t *l) {
 }
 
 slot_layer_t *layers_new_layer(bool clear, i32 position, slot_layer_t *parent) {
-	if (g_project->_->layers->length > layers_max_layers) {
+	if (g_project->_->layers->length >= layers_max_layers) {
 		return NULL;
 	}
 
 	slot_layer_t *l = slot_layer_create("", LAYER_SLOT_TYPE_LAYER, parent);
+	if (l == NULL) {
+		return NULL;
+	}
 	l->object_mask  = g_context->layer_filter;
 
 	if (position == -1 && slot_layer_is_filter(l)) {
@@ -627,11 +633,14 @@ void layers_new_mask_clear(slot_layer_t *l) {
 }
 
 slot_layer_t *layers_new_mask(bool clear, slot_layer_t *parent, i32 position) {
-	if (g_project->_->layers->length > layers_max_layers) {
+	if (g_project->_->layers->length >= layers_max_layers) {
 		return NULL;
 	}
 
 	slot_layer_t *l = slot_layer_create("", LAYER_SLOT_TYPE_MASK, parent);
+	if (l == NULL) {
+		return NULL;
+	}
 	if (position == -1) {
 		position = array_index_of(g_project->_->layers, parent);
 	}
@@ -645,11 +654,14 @@ slot_layer_t *layers_new_mask(bool clear, slot_layer_t *parent, i32 position) {
 }
 
 slot_layer_t *layers_new_group() {
-	if (g_project->_->layers->length > layers_max_layers) {
+	if (g_project->_->layers->length >= layers_max_layers) {
 		return NULL;
 	}
 
 	slot_layer_t *l = slot_layer_create("", LAYER_SLOT_TYPE_GROUP, NULL);
+	if (l == NULL) {
+		return NULL;
+	}
 	any_array_push(g_project->_->layers, l);
 	context_set_layer(l);
 	return l;
@@ -686,6 +698,9 @@ slot_layer_t *layers_new_path_layer(bool curved) {
 
 void layers_create_fill_layer_on_next_frame(void *_) {
 	slot_layer_t *l = layers_new_layer(false, _layers_position, NULL);
+	if (l == NULL) {
+		return;
+	}
 	history_new_layer();
 	l->uv_type = _layers_uv_type;
 	if (!mat4_isnan(_layers_decal_mat)) {
@@ -723,6 +738,9 @@ void layers_create_filter_on_next_frame(void *_) {
 	tab_materials_button_new_on_next_frame(NULL);
 
 	slot_layer_t *l = layers_new_layer(false, -1, g_context->layer);
+	if (l == NULL) {
+		return;
+	}
 	history_new_layer();
 	history_to_fill_layer();
 	slot_layer_to_fill_layer(l);
@@ -773,21 +791,30 @@ void layers_create_image_mask(asset_t *asset) {
 		return;
 	}
 
-	history_new_layer();
 	slot_layer_t *m = layers_new_mask(false, l, -1);
+	if (m == NULL) {
+		return;
+	}
+	history_new_layer();
 	slot_layer_clear(m, 0x00000000, project_get_image(asset), 1.0, layers_default_rough, 0.0);
 	g_context->layer_preview_dirty = true;
 }
 
 void layers_create_image_layer(asset_t *asset) {
-	history_new_layer();
 	slot_layer_t *m = layers_new_layer(false, -1, NULL);
+	if (m == NULL) {
+		return;
+	}
+	history_new_layer();
 	slot_layer_clear(m, 0x00000000, project_get_image(asset), 1.0, layers_default_rough, 0.0);
 	g_context->layer_preview_dirty = true;
 }
 
 void layers_create_color_layer_on_next_frame(void *_) {
 	slot_layer_t *l = layers_new_layer(false, _layers_position, NULL);
+	if (l == NULL) {
+		return;
+	}
 	history_new_layer();
 	l->uv_type     = UV_TYPE_UVMAP;
 	l->object_mask = g_context->layer_filter;
@@ -822,6 +849,9 @@ void layers_duplicate_layer(slot_layer_t *l) {
 	}
 	else {
 		slot_layer_t *new_group = layers_new_group();
+		if (new_group == NULL) {
+			return;
+		}
 		array_remove(g_project->_->layers, new_group);
 		array_insert(g_project->_->layers, array_index_of(g_project->_->layers, l) + 1, new_group);
 		// group.show_panel = true;

--- a/paint/tests/test_priority_fixes.py
+++ b/paint/tests/test_priority_fixes.py
@@ -1,0 +1,71 @@
+"""Source-level regression checks for the priority issue fixes.
+
+The checkout does not contain a native unit-test runner for the paint target,
+so these checks protect the exact defensive boundaries while the generated
+native project is used for compile-time verification.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(*parts: str) -> str:
+    return (ROOT.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+def test_config_scale_is_validated_at_boundaries() -> None:
+    config = read("paint", "sources", "config.c")
+    preferences = read("paint", "sources", "ui", "box_preferences.c")
+    assert "f32 config_validate_window_scale" in config
+    assert config.count("config_validate_window_scale") >= 4
+    assert "g_config->window_scale = config_validate_window_scale(g_config->window_scale);" in preferences
+
+
+def test_opacity_is_clamped_after_pressure_multipliers() -> None:
+    uniforms = read("paint", "sources", "uniforms.c")
+    paint = read("paint", "sources", "render", "render_path_paint.c")
+    assert "return fminf(fmaxf(val, 0.0), 1.0);" in uniforms
+    assert "fminf(fmaxf(opacity, 0.0), 1.0)" in paint
+
+
+def test_blender_import_stops_when_temp_obj_is_missing() -> None:
+    source = read("paint", "sources", "io", "import_blend_mesh.c")
+    assert "iron_file_exists(save)" in source
+    assert "import_obj_run(save, replace_existing);" in source
+
+
+def test_pack_and_preset_exports_validate_missing_data() -> None:
+    arm = read("paint", "sources", "io", "export_arm.c")
+    preset = read("paint", "sources", "ui", "box_export.c")
+    texture = read("paint", "sources", "io", "export_texture.c")
+    assert "bool export_arm_pack_assets" in arm
+    assert "if (image == NULL)" in arm
+    assert "if (!export_arm_pack_assets" in arm
+    assert "if (blob == NULL)" in preset
+    assert "layers->length == 0" in texture
+    assert "No valid export preset available" in texture
+
+
+def test_layer_creation_and_2d_view_are_null_safe() -> None:
+    layers = read("paint", "sources", "util", "util_layer.c")
+    slot_layer = read("paint", "sources", "slot_layer.c")
+    view = read("paint", "sources", "ui", "ui_view2d.c")
+    assert ">= layers_max_layers" in layers
+    assert layers.count("if (l == NULL)") >= 3
+    assert "raw == NULL || g_context->material == NULL" in slot_layer
+    assert "if (tex != NULL)" in view
+
+
+def test_history_mask_restore_and_redo_scan_are_bounded() -> None:
+    history = read("paint", "sources", "history.c")
+    assert "history_undo_delete_layer_masks" in history
+    assert "active + n < history_steps->length" in history
+
+
+if __name__ == "__main__":
+    tests = [value for name, value in globals().items() if name.startswith("test_") and callable(value)]
+    for test in tests:
+        test()
+    print(f"{len(tests)} regression checks passed")


### PR DESCRIPTION
## Summary

Draft patch for the priority issue triage. The changes add defensive validation at the boundaries where malformed config, missing GPU/file data, failed layer creation, and history traversal previously reached unchecked dereferences.

## Issue coverage

- #2082: validate UI scale on config load, import, save, and UI application; invalid values fall back to 1.0.
- #2084: clamp brush opacity after node, pressure, and cursor multipliers.
- #2052: write Blender's temporary OBJ to the user-writable internal save path, remove stale output, and stop cleanly when Blender produces no OBJ.
- #2065: make packed-asset export report missing/unloaded assets and abort before writing a partial packed project.
- #2080: validate export presets and layer inputs before texture export; provide a generic preset fallback for missing/corrupt preset data.
- #2090: keep 2D touch-view input safe when the active layer has no paint texture.
- #792: restore masks from the same layer-delete operation together during undo and bound redo scanning; avoid using deleted layer pointers in the UI delete path.
- #2062: make fill-mask/layer conversion and maximum-layer creation failure-safe, including sculpt-layer creation.

## Verification

- `python paint/tests/test_priority_fixes.py` -> 6 regression checks passed.
- GCC `-fsyntax-only` passed for all changed C translation units.
- `paint\\..\\base\\make.bat --help` generated the Windows project files and compiled all bundled shaders successfully.
- The native MSBuild attempt is currently blocked by the environment: Visual Studio C++ targets (`Microsoft.Cpp.Default.props` / `MSBuild.exe`) are not installed. Linux/Vulkan and GPU-specific issue reproduction was not possible in this Windows checkout.

This is intentionally a draft so the upstream maintainer can review the platform-specific paths and run the native Linux/Windows runtime scenarios.