### PR TITLE
Clamp brush opacity after pressure modifiers

### DIFF
--- a/paint/sources/render/render_path_paint.c
+++ b/paint/sources/render/render_path_paint.c
@@ -704,6 +704,7 @@ void render_path_paint_draw_cursor_decal(f32 mx, f32 my, f32 radius, f32 opacity
 	gpu_set_float3(pipes_cursor_decal_camera_up, up.x, up.y, up.z);
 	gpu_set_float(pipes_cursor_decal_camera_align, context_is_brush_camera_align() ? 1.0f : 0.0f);
 	f32 opacity = g_context->brush_opacity * brush_nodes_opacity * opacity_scale;
+	opacity     = fminf(fmaxf(opacity, 0.0), 1.0);
 	gpu_set_float(pipes_cursor_decal_opacity, opacity);
 	f32 angle = (g_context->brush_angle + brush_nodes_angle) * (math_pi() / 180.0);
 	gpu_set_float2(pipes_cursor_decal_angle, math_cos(angle), math_sin(angle));

--- a/paint/sources/uniforms.c
+++ b/paint/sources/uniforms.c
@@ -69,7 +69,7 @@ f32 uniforms_ext_f32_link(object_t *object, material_data_t *mat, char *link) {
 		if (g_config->pressure_opacity && (pen_down("tip") || pen_released("tip")) && !slot_layer_is_path(g_context->layer)) {
 			val *= pen_pressure * g_config->pressure_sensitivity;
 		}
-		return val;
+		return fminf(fmaxf(val, 0.0), 1.0);
 	}
 	else if (string_equals(link, "_brush_hardness")) {
 		bool decal_mask = context_is_decal_mask_paint_pass();

--- a/paint/tests/test_issue_2084.py
+++ b/paint/tests/test_issue_2084.py
@@ -1,0 +1,26 @@
+"""Regression checks for bounded brush opacity."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(*parts: str) -> str:
+	return ROOT.joinpath(*parts).read_text(encoding="utf-8")
+
+
+def test_brush_opacity_is_clamped_after_all_multipliers() -> None:
+	uniforms = read("paint", "sources", "uniforms.c")
+	assert "return fminf(fmaxf(val, 0.0), 1.0);" in uniforms
+
+
+def test_decal_cursor_uses_the_same_opacity_range() -> None:
+	render = read("paint", "sources", "render", "render_path_paint.c")
+	assert "opacity     = fminf(fmaxf(opacity, 0.0), 1.0);" in render
+
+
+if __name__ == "__main__":
+	test_brush_opacity_is_clamped_after_all_multipliers()
+	test_decal_cursor_uses_the_same_opacity_range()
+	print("2 regression checks passed")


### PR DESCRIPTION
## Summary
- clamp final brush opacity after node and pressure multipliers
- clamp the decal cursor preview through the same range
- add focused regression checks

## Root cause
Brush opacity could exceed 1.0 after pressure and node multipliers, producing invalid paint and preview opacity.

## Validation
- `python paint/tests/test_issue_2084.py`
- Local native project generation is currently blocked by the bundled `amake` stack-overflow error; GitHub platform builds will provide compile validation.

Fixes #2084