### PR TITLE
Scope face fill triangle map to selected UDIM

### DIFF
--- a/paint/sources/util/util_uv.c
+++ b/paint/sources/util/util_uv.c
@@ -70,7 +70,8 @@ void util_uv_cache_triangle_map() {
 	}
 
 	util_uv_trianglemap_cached = true;
-	mesh_data_t *merged        = g_context->merged_object != NULL ? g_context->merged_object->data : g_context->paint_object->data;
+	bool selected_paint_object = context_layer_filter_used() || context_object_mask_used();
+	mesh_data_t *merged = !selected_paint_object && g_context->merged_object != NULL ? g_context->merged_object->data : g_context->paint_object->data;
 	mesh_data_t *mesh          = merged;
 	i16_array_t *texa          = mesh->vertex_arrays->buffer[2]->values;
 	u32_array_t *inda          = mesh->index_array;

--- a/paint/tests/test_issue_2081.py
+++ b/paint/tests/test_issue_2081.py
@@ -1,0 +1,21 @@
+"""Regression checks for UDIM-aware face-fill triangle maps."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(*parts: str) -> str:
+	return ROOT.joinpath(*parts).read_text(encoding="utf-8")
+
+
+def test_filtered_udim_triangle_map_uses_the_selected_paint_object() -> None:
+	uv = read("paint", "sources", "util", "util_uv.c")
+	assert "context_layer_filter_used() || context_object_mask_used()" in uv
+	assert "g_context->paint_object->data" in uv
+
+
+if __name__ == "__main__":
+	test_filtered_udim_triangle_map_uses_the_selected_paint_object()
+	print("1 regression check passed")


### PR DESCRIPTION
## Summary
- use the selected paint object for the face-fill triangle map when a layer or object filter is active
- retain merged-mesh behavior when no filter is active
- add a focused regression check

## Root cause
The triangle map was always generated from the merged mesh. Overlapping UVs from another UDIM could therefore overwrite the selected tile's face identity.

## Validation
- `python paint/tests/test_issue_2081.py`
- Local native project generation is currently blocked by the bundled `amake` stack-overflow error; GitHub platform builds will provide compile validation.

Fixes #2081