### PR TITLE
Reject OBJ UDIM faces spanning tiles

### DIFF
--- a/base/sources/iron_obj.c
+++ b/base/sources/iron_obj.c
@@ -192,6 +192,16 @@ static int get_tile(int i1, int i2, int i3, i32_array_t *uv_indices, int tiles_u
 	return tile_u + tile_v * tiles_u;
 }
 
+static bool face_spans_udim_tiles(int i1, int i2, int i3, i32_array_t *uv_indices) {
+	int u1 = (int)uv_temp.buffer[uv_indices->buffer[i1] * 2];
+	int v1 = (int)uv_temp.buffer[uv_indices->buffer[i1] * 2 + 1];
+	int u2 = (int)uv_temp.buffer[uv_indices->buffer[i2] * 2];
+	int v2 = (int)uv_temp.buffer[uv_indices->buffer[i2] * 2 + 1];
+	int u3 = (int)uv_temp.buffer[uv_indices->buffer[i3] * 2];
+	int v3 = (int)uv_temp.buffer[uv_indices->buffer[i3] * 2 + 1];
+	return u1 != u2 || u1 != u3 || v1 != v2 || v1 != v3;
+}
+
 static bool pnpoly(float v0x, float v0y, float v1x, float v1y, float v2x, float v2y, float px, float py) {
 	// https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
 	bool c = false;
@@ -558,7 +568,15 @@ raw_mesh_t *obj_parse(buffer_t *file_bytes, char split_code, uint64_t start_pos,
 			uint32_t *num = (uint32_t *)malloc(tiles_u * tiles_v * sizeof(uint32_t));
 			memset(num, 0, tiles_u * tiles_v * sizeof(uint32_t));
 			for (int i = 0; i < (int)(inda_length / 3); ++i) {
-				int tile = get_tile(part->inda->buffer[i * 3], part->inda->buffer[i * 3 + 1], part->inda->buffer[i * 3 + 2], &uv_indices, tiles_u);
+				int i1 = part->inda->buffer[i * 3];
+				int i2 = part->inda->buffer[i * 3 + 1];
+				int i3 = part->inda->buffer[i * 3 + 2];
+				if (face_spans_udim_tiles(i1, i2, i3, &uv_indices)) {
+					part->udim_split_invalid = true;
+					free(num);
+					return part;
+				}
+				int tile = get_tile(i1, i2, i3, &uv_indices, tiles_u);
 				num[tile] += 3;
 			}
 

--- a/base/sources/iron_obj.h
+++ b/base/sources/iron_obj.h
@@ -20,6 +20,7 @@ typedef struct raw_mesh {
 	bool              has_next; // File contains multiple objects
 	uint64_t          pos;
 	struct any_array *udims;   // u32_array_t[] - Indices split per udim tile
+	bool              udim_split_invalid;
 	int               udims_u; // Number of horizontal udim tiles
 	int               udims_v;
 	void             *vertex_arrays; // vertex_array_t[]

--- a/paint/sources/functions.h
+++ b/paint/sources/functions.h
@@ -419,6 +419,7 @@ char                     *strings_arm_file_expected();
 char                     *strings_unknown_asset_format();
 char                     *strings_could_not_locate_texture();
 char                     *strings_failed_to_read_mesh_data();
+char                     *strings_udim_face_spans_tiles();
 char                     *strings_check_internet_connection();
 char                     *strings_asset_already_imported();
 char                     *strings_graphics_api();

--- a/paint/sources/io/import_obj.c
+++ b/paint/sources/io/import_obj.c
@@ -10,6 +10,10 @@ void import_obj_run(char *path, bool replace_existing) {
 
 	if (is_udim) {
 		raw_mesh_t *part = obj_parse(b, split_code, 0, is_udim);
+		if (part->udim_split_invalid) {
+			console_error(strings_udim_face_spans_tiles());
+			return;
+		}
 		char       *name = part->name;
 		for (i32 i = 0; i < part->udims->length; ++i) {
 			u32_array_t *a = part->udims->buffer[i];

--- a/paint/sources/strings.c
+++ b/paint/sources/strings.c
@@ -17,6 +17,10 @@ char *strings_failed_to_read_mesh_data() {
 	return tr("Error: Failed to read mesh data");
 }
 
+char *strings_udim_face_spans_tiles() {
+	return tr("Error: A face spans multiple UDIM tiles");
+}
+
 char *strings_check_internet_connection() {
 	return tr("Error: Check internet connection to access the cloud");
 }

--- a/paint/tests/test_issue_1870.py
+++ b/paint/tests/test_issue_1870.py
@@ -1,0 +1,29 @@
+"""Regression checks for rejecting faces that span UDIM tiles."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(*parts: str) -> str:
+	return ROOT.joinpath(*parts).read_text(encoding="utf-8")
+
+
+def test_obj_parser_marks_spanning_udim_faces_invalid() -> None:
+	parser = read("base", "sources", "iron_obj.c")
+	header = read("base", "sources", "iron_obj.h")
+	assert "udim_split_invalid" in header
+	assert "part->udim_split_invalid = true;" in parser
+
+
+def test_obj_import_reports_the_invalid_udim_split() -> None:
+	importer = read("paint", "sources", "io", "import_obj.c")
+	assert "part->udim_split_invalid" in importer
+	assert "strings_udim_face_spans_tiles()" in importer
+
+
+if __name__ == "__main__":
+	test_obj_parser_marks_spanning_udim_faces_invalid()
+	test_obj_import_reports_the_invalid_udim_split()
+	print("2 regression checks passed")


### PR DESCRIPTION
## Summary
- detect OBJ faces whose vertices cross UDIM tile boundaries
- abort UDIM splitting with a localized error instead of continuing with an ambiguous tile
- add focused regression checks

## Root cause
The OBJ splitter assigned each face to its average UV tile. Faces crossing tiles could corrupt split bookkeeping and crash the import.

## Validation
- `python paint/tests/test_issue_1870.py`
- Local native project generation is currently blocked by the bundled `amake` stack-overflow error; GitHub platform builds will provide compile validation.

Fixes #1870