### PR TITLE
fix: release held input when the macOS window loses focus

### DIFF
--- a/base/sources/backends/macos_system.m
+++ b/base/sources/backends/macos_system.m
@@ -772,9 +772,25 @@ void iron_internal_call_resize_callback(int width, int height) {
 }
 
 - (void)windowDidResignMain:(NSNotification *)notification {
+	// Key-up and mouse-up events go to whichever app took focus, never to
+	// us - so anything held when the user switches away stays "down"
+	// forever and the input is partly frozen on return. Windows already
+	// handles this in WM_ACTIVATE; macOS was an empty stub. Release
+	// everything that can stick.
+	iron_internal_mouse_window_deactivated();
+	iron_internal_mouse_trigger_release(0, 0, 0);
+	iron_internal_mouse_trigger_release(1, 0, 0);
+	iron_internal_mouse_trigger_release(2, 0, 0);
+	iron_internal_keyboard_trigger_key_up(KEY_CODE_SHIFT);
+	iron_internal_keyboard_trigger_key_up(KEY_CODE_CONTROL);
+	iron_internal_keyboard_trigger_key_up(KEY_CODE_ALT);
+	iron_internal_keyboard_trigger_key_up(KEY_CODE_META);
+	iron_internal_background_callback();
 }
 
 - (void)windowDidBecomeMain:(NSNotification *)notification {
+	iron_internal_mouse_window_activated();
+	iron_internal_foreground_callback();
 }
 
 @end


### PR DESCRIPTION
Hi, I was trying ArmorPaint on macOS and noticed that some of the input was getting lost when switching applications. I asked Claude to take a look and came up with this change that seems to fix it:

Key-up and mouse-up events are delivered to whichever application takes focus, so anything held down when the user switches away stays down and the input is partly frozen on return. windowDidResignMain was an empty stub, and only miniaturising fired the background callback - which app switching does not do.

Release the mouse buttons and modifier keys on resign, and pair the activate side with mouse_window_activated plus the foreground callback. This mirrors what the Windows backend already does in WM_ACTIVATE.

Assisted-by: Claude:claude-opus-5 [debugging] [patch]