### PR TITLE
fix(build): make base --run invoke paint target to resolve kickstart link failure

### DIFF
--- a/base/make
+++ b/base/make
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
-. `dirname "$0"`/tools/platform.sh
-MAKE="`dirname "$0"`/tools/bin/$IRON_PLATFORM/amake"
-exec $MAKE `dirname "$0"`/tools/make.js "$@"
+. "$(dirname "$0")/tools/platform.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAKE="$SCRIPT_DIR/tools/bin/$IRON_PLATFORM/amake"
+
+if [ "$(pwd)" = "$SCRIPT_DIR" ] \
+   && [ -f "$SCRIPT_DIR/../paint/project.js" ] \
+   && [[ " $* " == *" --run "* ]] \
+   && [[ " $* " != *" --js "* ]]; then
+	cd "$SCRIPT_DIR/../paint" || exit 1
+fi
+
+exec "$MAKE" "$SCRIPT_DIR/tools/make.js" "$@"


### PR DESCRIPTION
Output from Ubuntu 26.04 prior to this patch:

linux_system.c:(.text.main+0x1): undefined reference to `kickstart'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [makefile:8: Base] Error 1